### PR TITLE
Add a has_monitors? method to Selector

### DIFF
--- a/ext/nio4r/org/nio4r/Nio4r.java
+++ b/ext/nio4r/org/nio4r/Nio4r.java
@@ -130,6 +130,12 @@ public class Nio4r implements Library {
             Ruby runtime = context.getRuntime();
             return this.selector.isOpen() ? runtime.getFalse() : runtime.getTrue();
         }
+        
+        @JRubyMethod(name = "empty?")
+        public IRubyObject isEmpty(ThreadContext context) {
+            Ruby runtime = context.getRuntime();
+            return this.selector.keys().isEmpty() ? runtime.getTrue() : runtime.getFalse();
+        }
 
         @JRubyMethod
         public IRubyObject register(ThreadContext context, IRubyObject io, IRubyObject interests) {

--- a/ext/nio4r/selector.c
+++ b/ext/nio4r/selector.c
@@ -28,6 +28,7 @@ static VALUE NIO_Selector_select(int argc, VALUE *argv, VALUE self);
 static VALUE NIO_Selector_wakeup(VALUE self);
 static VALUE NIO_Selector_close(VALUE self);
 static VALUE NIO_Selector_closed(VALUE self);
+static VALUE NIO_Selector_is_empty(VALUE self);
 
 /* Internal functions */
 static VALUE NIO_Selector_synchronize(VALUE self, VALUE (*func)(VALUE *args), VALUE *args);
@@ -60,6 +61,7 @@ void Init_NIO_Selector()
     rb_define_method(cNIO_Selector, "wakeup", NIO_Selector_wakeup, 0);
     rb_define_method(cNIO_Selector, "close", NIO_Selector_close, 0);
     rb_define_method(cNIO_Selector, "closed?", NIO_Selector_closed, 0);
+    rb_define_method(cNIO_Selector, "empty?", NIO_Selector_is_empty, 0);
 
     cNIO_Monitor = rb_define_class_under(mNIO, "Monitor",  rb_cObject);
 }
@@ -392,6 +394,15 @@ static VALUE NIO_Selector_closed(VALUE self)
 
     return selector->closed ? Qtrue : Qfalse;
 }
+
+/* True if there are monitors on the loop */
+static VALUE NIO_Selector_is_empty(VALUE self)
+{
+    VALUE selectables = rb_ivar_get(self, rb_intern("selectables"));
+    
+    return rb_funcall(selectables, rb_intern("empty?"), 0) == Qtrue ? Qtrue : Qfalse;
+}
+
 
 /* Called whenever a timeout fires on the event loop */
 static void NIO_Selector_timeout_callback(struct ev_loop *ev_loop, struct ev_timer *timer, int revents)

--- a/lib/nio/selector.rb
+++ b/lib/nio/selector.rb
@@ -132,5 +132,9 @@ module NIO
 
     # Is this selector closed?
     def closed?; @closed end
+    
+    def empty?
+      @selectables.empty?
+    end
   end
 end

--- a/spec/nio/selector_spec.rb
+++ b/spec/nio/selector_spec.rb
@@ -34,6 +34,14 @@ describe NIO::Selector do
     subject.should_not be_registered(reader)
     monitor.should be_closed
   end
+  
+  it "reports if it is empty" do
+    subject.should be_empty
+    
+    monitor = subject.register(reader, :r)
+    
+    subject.should_not be_empty
+  end
 
   # This spec might seem a bit silly, but this actually something the
   # Java NIO API specifically precludes that we need to work around


### PR DESCRIPTION
hello, 

I added a method, has_monitors?, to Selector which is handy if you need to determine if it's time to terminate an event loop. I tested this on Ruby1.9, but I haven't tested the other platforms or the Ruby-only. 
