### PR TITLE
SSL Socket test sometimes loops forever

### DIFF
--- a/spec/nio/selectables/ssl_socket_spec.rb
+++ b/spec/nio/selectables/ssl_socket_spec.rb
@@ -108,10 +108,13 @@ if RUBY_VERSION > "1.9.0"
       speer.accept
 
       begin
-        sclient.write_nonblock "X" * 1024
         _, writers = select [], [sclient], [], 0
+        count = sclient.write_nonblock "X" * 1024
+        count.should_not == 0
       rescue IO::WaitReadable, IO::WaitWritable
-      end while writers and writers.include? sclient
+        pending "SSL will report writable but not accept writes"
+        raise if(writers.include? sclient)
+      end while writers.include? sclient
 
       # I think the kernel might manage to drain its buffer a bit even after
       # the socket first goes unwritable. Attempt to sleep past this and then


### PR DESCRIPTION
Hello, 

On my OS X Mac, the SSL socket test will sometimes enter an infinite loop trying to create an unwritable SSL socket. The reason is that Kernel#select will report the socket writable event though write_nonblock throws an exception when any data is written. I've restructured the logic to trap this condition with a "pending" block (though I cannot confirm that the test passes on other machines). 
