### PR TITLE
Remove hardcoded port offsets

### DIFF
--- a/spec/nio/selectables/tcp_socket_spec.rb
+++ b/spec/nio/selectables/tcp_socket_spec.rb
@@ -66,7 +66,8 @@ describe TCPSocket do
 
   it_behaves_like "an NIO selectable"
   it_behaves_like "an NIO selectable stream"
-
+  it_behaves_like "an NIO bidirectional stream"
+  
   context :connect do
     it "selects writable when connected" do
       selector = NIO::Selector.new

--- a/spec/support/selectable_examples.rb
+++ b/spec/support/selectable_examples.rb
@@ -36,6 +36,21 @@ shared_context "an NIO selectable stream" do
     selector.select(0).should be_nil
 
     peer.close
-    selector.select(0).should include monitor
+    #Wait and give the TCP session time to close
+    selector.select(0.1).should include monitor
   end
+end
+
+shared_context "an NIO bidirectional stream" do
+  let(:selector) { NIO::Selector.new }
+  let(:stream)   { pair.first }
+  let(:peer)     { pair.last }
+
+  it "selects readable and writable" do
+    monitor = selector.register(readable_subject, :rw)
+    selector.select(0) do |m|
+      m.readiness.should == :rw
+    end
+  end
+  
 end


### PR DESCRIPTION
Hello, 

The tests in tcp_socket_spec use hard-coded port offsets. I was adding another test (pull request TBD), and this breaks because if you attempt to use a method that was used in a previous test (e.g. readable_subject), the old socket will still be open and on OS X the test will hang forever. 

Almost straight out of the rspec docs, this change memoizes a unique port offset for each test run. 
