### PR TITLE
Fix for broken monitor spec

### DIFF
--- a/spec/nio/monitor_spec.rb
+++ b/spec/nio/monitor_spec.rb
@@ -6,12 +6,12 @@ describe NIO::Monitor do
   let(:writer) { pipes.last }
   let(:selector) { NIO::Selector.new }
 
-  subject    { selector.register(reader, :rw) }
+  subject    { selector.register(reader, :r) }
   let(:peer) { selector.register(writer, :rw) }
   after      { selector.close }
 
   it "knows its interests" do
-    subject.interests.should == :rw
+    subject.interests.should == :r
     peer.interests.should == :rw
   end
 


### PR DESCRIPTION
I was fiddling with nio4r and I noticed that a monitor spec was failing because it listened rw on the read end of a pipe but asserted that it wasn't in the list of selectables. 
