### PR TITLE
Fix broken specs on OS X 10.8

### DIFF
--- a/spec/nio/selectables/pipe_spec.rb
+++ b/spec/nio/selectables/pipe_spec.rb
@@ -18,8 +18,13 @@ describe "IO.pipe" do
   let :unwritable_subject do
     reader, pipe = IO.pipe
 
+    #HACK: On OS X 10.8, this str must be larger than PIPE_BUF. Otherwise,
+    #      the write is atomic and select() will return writable but write()
+    #      will throw EAGAIN if there is too little space to write the string
+    # TODO: Use FFI to lookup the platform-specific size of PIPE_BUF
+    str = "JUNK IN THE TUBES" * 10000
     begin
-      pipe.write_nonblock "JUNK IN THE TUBES"
+      pipe.write_nonblock str
       _, writers = select [], [pipe], [], 0
     rescue Errno::EPIPE
       break


### PR DESCRIPTION
Tests involving unwritable_subject were failing for me on OS X 10.8, this patch fixes it. 

Of note, in OS X select() will report some pipes as writable, however, a write() call to the pipe with fewer than PIPE_BUF bytes will fail with EAGAIN. This is because all writes less than PIPE_BUF in size are guaranteed to be atomic so the OS will fail the whole call if there is not enough space rather than do a partial write. This behavior is somewhat nonsensical and has implications for any non-blocking I/O frameworks on OS X as it is no longer possible to determine when a write to a pipe might succeed. 

This patch at least works around the problem by writing a very large string that is bigger than PIPE_BUF on basically all platforms. Kinda hackey, but at least it works. 
