### PR TITLE
Add the existing monitor interests to the exception

### DIFF
--- a/lib/nio/selector.rb
+++ b/lib/nio/selector.rb
@@ -18,7 +18,9 @@ module NIO
     # * :rw - is the IO either readable or writeable?
     def register(io, interest)
       @lock.synchronize do
-        raise ArgumentError, "this IO is already registered with the selector" if @selectables[io]
+        if monitor = @selectables[io]
+          raise ArgumentError, "this IO is already registered with the selector as #{monitor.interests.inspect}"
+        end
 
         monitor = Monitor.new(io, interest, self)
         @selectables[io] = monitor


### PR DESCRIPTION
Related to celluloid/celluloid-io#23, I added the interests of the existing monitor in an attempt to discover what was happening. 
