### PR TITLE
Add missing returns in Selector_synchronize and Selector_unlock

### DIFF
--- a/ext/nio4r/selector.c
+++ b/ext/nio4r/selector.c
@@ -170,7 +170,7 @@ static VALUE NIO_Selector_synchronize(VALUE self, VALUE (*func)(VALUE *args), VA
         return rb_ensure(func, (VALUE)args, NIO_Selector_unlock, self);
     } else {
         /* We already hold the selector lock, so no need to unlock it */
-        func(args);
+        return func(args);
     }
 }
 
@@ -183,6 +183,8 @@ static VALUE NIO_Selector_unlock(VALUE self)
 
     lock = rb_ivar_get(self, rb_intern("lock"));
     rb_funcall(lock, rb_intern("unlock"), 0, 0);
+
+    return Qnil;
 }
 
 /* Register an IO object with the selector for the given interests */


### PR DESCRIPTION
This fixes seg faults and erroneous errors on ruby 2.0.0-p0. 

https://gist.github.com/halorgium/b1dda35041a47a344fca
