### PR TITLE
Fixed nio4r to work correctly on JRuby/Windows again

### DIFF
--- a/lib/nio.rb
+++ b/lib/nio.rb
@@ -11,7 +11,7 @@ module NIO
   def self.engine; ENGINE end
 end
 
-if ENV["NIO4R_PURE"] || ENV["OS"] =~ /Windows/i
+if ENV["NIO4R_PURE"] || (ENV["OS"] =~ /Windows/i && !defined?(JRUBY_VERSION))
   require 'nio/monitor'
   require 'nio/selector'
   NIO::ENGINE = 'select'


### PR DESCRIPTION
Hi,

I noticed that nio4r doesn't currently work correctly on JRuby/Windows, because of a previous pull request (https://github.com/tarcieri/nio4r/pull/21). The error we're getting is:

```
SystemCallError: Unknown error - Unknown Error (20047) - -1
        org/jruby/RubyIO.java:3197:in `stat'
        Y:/Work/Source/hg/eCraft.appFactory-2013.6/src/server/gems/jruby/1.9/gems/nio4r-0.4.5-java/lib/nio/selector.rb:66:in `select'
        org/jruby/RubyArray.java:1613:in `each'
        Y:/Work/Source/hg/eCraft.appFactory-2013.6/src/server/gems/jruby/1.9/gems/nio4r-0.4.5-java/lib/nio/selector.rb:62:in `select'
        org/jruby/ext/thread/Mutex.java:149:in `synchronize'
        Y:/Work/Source/hg/eCraft.appFactory-2013.6/src/server/gems/jruby/1.9/gems/nio4r-0.4.5-java/lib/nio/selector.rb:48:in `select'
```

The attached pull requests fixes this by making JRuby/Windows not use the "pure" implementation (which is non-functional on this platform because of running 'stat' on an IO.pipe()-reader is seemingly broken).
