### PR TITLE
Remove ruby warning

### DIFF
--- a/ext/nio4r/selector.c
+++ b/ext/nio4r/selector.c
@@ -149,6 +149,7 @@ static VALUE NIO_Selector_initialize(VALUE self)
 
     lock = rb_class_new_instance(0, 0, rb_const_get(rb_cObject, rb_intern("Mutex")));
     rb_ivar_set(self, rb_intern("lock"), lock);
+    rb_ivar_set(self, rb_intern("lock_holder"), Qnil);
 
     return Qnil;
 }


### PR DESCRIPTION
``` ruby
require 'nio'
selector = NIO::Selector.new
socket = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
selector.register(socket, :w) # !> instance variable lock_holder not initialized
```
