### PR TITLE
require 'set' library in selector.rb

### DIFF
--- a/lib/nio/selector.rb
+++ b/lib/nio/selector.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module NIO
   # Selectors monitor IO objects for events of interest
   class Selector


### PR DESCRIPTION
Currently it makes assumption that 'set.rb' loaded
