### PR TITLE
Fix flaky specs

### DIFF
--- a/spec/nio/acceptables_spec.rb
+++ b/spec/nio/acceptables_spec.rb
@@ -17,16 +17,16 @@ RSpec.describe "NIO acceptables" do
   end
 
   describe TCPServer do
-    let(:tcp_port) { 23_456 }
+    let(:port) { next_available_tcp_port }
 
     let :acceptable_subject do
-      server = TCPServer.new("localhost", tcp_port)
-      TCPSocket.open("localhost", tcp_port)
+      server = TCPServer.new("localhost", port)
+      TCPSocket.open("localhost", port)
       server
     end
 
     let :unacceptable_subject do
-      TCPServer.new("localhost", tcp_port + 1)
+      TCPServer.new("localhost", port + 1)
     end
 
     it_behaves_like "an NIO acceptable"

--- a/spec/nio/bytebuffer_spec.rb
+++ b/spec/nio/bytebuffer_spec.rb
@@ -281,8 +281,8 @@ RSpec.describe NIO::ByteBuffer do
   end
 
   context "I/O" do
-    let(:addr)   { "127.0.0.1" }
-    let(:port)   { 54_321 }
+    let(:addr)   { "localhost" }
+    let(:port)   { next_available_tcp_port }
     let(:server) { TCPServer.new(addr, port) }
     let(:client) { TCPSocket.new(addr, port) }
     let(:peer)   { server_thread.value }

--- a/spec/nio/selectables/pipe_spec.rb
+++ b/spec/nio/selectables/pipe_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "IO.pipe" do
   end
 
   let :unwritable_subject do
-    pipe = pair.last
+    _reader, pipe = pair
 
     # HACK: On OS X 10.8, this str must be larger than PIPE_BUF. Otherwise,
     #      the write is atomic and select() will return writable but write()

--- a/spec/nio/selectables/ssl_socket_spec.rb
+++ b/spec/nio/selectables/ssl_socket_spec.rb
@@ -3,8 +3,9 @@
 require "spec_helper"
 require "openssl"
 
-RSpec.describe OpenSSL::SSL::SSLSocket, if: RUBY_VERSION >= "1.9.0" do
-  let(:tcp_port) { 34_567 }
+RSpec.describe OpenSSL::SSL::SSLSocket do
+  let(:addr) { "localhost" }
+  let(:port) { next_available_tcp_port }
 
   let(:ssl_key) { OpenSSL::PKey::RSA.new(1024) }
 
@@ -31,8 +32,8 @@ RSpec.describe OpenSSL::SSL::SSLSocket, if: RUBY_VERSION >= "1.9.0" do
   end
 
   let :readable_subject do
-    server = TCPServer.new("localhost", tcp_port)
-    client = TCPSocket.open("localhost", tcp_port)
+    server = TCPServer.new(addr, port)
+    client = TCPSocket.open(addr, port)
     peer = server.accept
 
     ssl_peer = OpenSSL::SSL::SSLSocket.new(peer, ssl_server_context)
@@ -54,8 +55,8 @@ RSpec.describe OpenSSL::SSL::SSLSocket, if: RUBY_VERSION >= "1.9.0" do
   end
 
   let :unreadable_subject do
-    server = TCPServer.new("localhost", tcp_port + 1)
-    client = TCPSocket.new("localhost", tcp_port + 1)
+    server = TCPServer.new(addr, port)
+    client = TCPSocket.new(addr, port)
     peer = server.accept
 
     ssl_peer = OpenSSL::SSL::SSLSocket.new(peer, ssl_server_context)
@@ -74,8 +75,8 @@ RSpec.describe OpenSSL::SSL::SSLSocket, if: RUBY_VERSION >= "1.9.0" do
   end
 
   let :writable_subject do
-    server = TCPServer.new("localhost", tcp_port + 2)
-    client = TCPSocket.new("localhost", tcp_port + 2)
+    server = TCPServer.new(addr, port)
+    client = TCPSocket.new(addr, port)
     peer = server.accept
 
     ssl_peer = OpenSSL::SSL::SSLSocket.new(peer, ssl_server_context)
@@ -94,8 +95,8 @@ RSpec.describe OpenSSL::SSL::SSLSocket, if: RUBY_VERSION >= "1.9.0" do
   end
 
   let :unwritable_subject do
-    server = TCPServer.new("localhost", tcp_port + 3)
-    client = TCPSocket.open("localhost", tcp_port + 3)
+    server = TCPServer.new(addr, port)
+    client = TCPSocket.new(addr, port)
     peer = server.accept
 
     ssl_peer = OpenSSL::SSL::SSLSocket.new(peer, ssl_server_context)
@@ -142,8 +143,8 @@ RSpec.describe OpenSSL::SSL::SSLSocket, if: RUBY_VERSION >= "1.9.0" do
   let :pair do
     pending "figure out why newly created sockets are selecting readable immediately"
 
-    server = TCPServer.new("localhost", tcp_port + 4)
-    client = TCPSocket.open("localhost", tcp_port + 4)
+    server = TCPServer.new(addr, port)
+    client = TCPSocket.new(addr, port)
     peer = server.accept
 
     ssl_peer = OpenSSL::SSL::SSLSocket.new(peer, ssl_server_context)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,3 +9,19 @@ require "nio"
 require "support/selectable_examples"
 
 RSpec.configure(&:disable_monkey_patching!)
+
+$current_tcp_port = 10_000
+
+def next_available_tcp_port
+  loop do
+    $current_tcp_port += 1
+
+    begin
+      sock = Timeout.timeout(0.1) { TCPSocket.new("localhost", $current_tcp_port) }
+    rescue Errno::ECONNREFUSED
+      break $current_tcp_port
+    end
+
+    sock.close
+  end
+end


### PR DESCRIPTION
Picking up from #120 with a different branch name

This includes a couple fixes to make the specs more reliable, like a reliable TCP port allocator that ensures the ports are not in use before the tests run.