### PR TITLE
libev backend: Determine timeout vs wakeup by tracking wakeups

### DIFF
--- a/ext/nio4r/nio4r.h
+++ b/ext/nio4r/nio4r.h
@@ -16,9 +16,10 @@ struct NIO_Selector
     struct ev_timer timer; /* for timeouts */
     struct ev_io wakeup;
 
-    int wakeup_reader, wakeup_writer;
-    int closed, selecting, timed_out;
     int ready_count;
+    int closed, selecting;
+    int wakeup_reader, wakeup_writer;
+    volatile int wakeup_fired;
 
     VALUE ready_array;
 };


### PR DESCRIPTION
This changes the tracking of how to determine a timeout versus wakeup event by
tracking the firing of wakeups.

Attempting to use the timeout callback instead had apparent false positives for
failed timeouts.

This approach is also equivalent to what's used in the JRuby extension.