### PR TITLE
Use rspec-retry to work around sporadic OS X test failures (fixes #65)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ end
 group :development, :test do
   gem "coveralls",         require: false
   gem "rake-compiler",     require: false
-  gem "rspec",   "~> 3",   require: false
+  gem "rspec", "~> 3",     require: false
+  gem "rspec-retry",       require: false
   gem "rubocop", "0.46.0", require: false
 end

--- a/spec/nio/selectables/tcp_socket_spec.rb
+++ b/spec/nio/selectables/tcp_socket_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe TCPSocket do
   it_behaves_like "an NIO bidirectional stream"
 
   context :connect do
-    it "selects writable when connected" do
+    it "selects writable when connected", retry: 5 do # retry: Flaky on OS X
       begin
         server = TCPServer.new(addr, port)
         selector = NIO::Selector.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,12 +3,15 @@
 require "coveralls"
 Coveralls.wear!
 
-require "rubygems"
-require "bundler/setup"
 require "nio"
 require "support/selectable_examples"
+require "rspec/retry"
 
-RSpec.configure(&:disable_monkey_patching!)
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+  config.verbose_retry = true
+  config.display_try_failure_messages = true
+end
 
 $current_tcp_port = 10_000
 

--- a/spec/support/selectable_examples.rb
+++ b/spec/support/selectable_examples.rb
@@ -3,7 +3,7 @@
 RSpec.shared_context "an NIO selectable" do
   let(:selector) { NIO::Selector.new }
 
-  it "selects readable objects" do
+  it "selects readable objects", retry: 5 do # retry: Flaky on OS X
     monitor = selector.register(readable_subject, :r)
     ready = selector.select(0)
     expect(ready).to be_an Enumerable
@@ -51,7 +51,7 @@ RSpec.shared_context "an NIO bidirectional stream" do
   let(:stream)   { pair.first }
   let(:peer)     { pair.last }
 
-  it "selects readable and writable" do
+  it "selects readable and writable", retry: 5 do # retry: Flaky on OS X
     selector.register(readable_subject, :rw)
     selector.select(0) do |m|
       expect(m.readiness).to eq(:rw)


### PR DESCRIPTION
Though the specs (now) pass reliably on Linux, they are flaky on OS X.

This uses rspec-retry to rerun them, so they should hopefully pass reliably locally on OS X.