### PR TITLE
Monitor interests API improvements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,7 @@ Metrics/MethodLength:
   Max: 50
 
 Metrics/CyclomaticComplexity:
-  Max: 10
+  Max: 15
 
 Metrics/PerceivedComplexity:
   Max: 15

--- a/ext/nio4r/monitor.c
+++ b/ext/nio4r/monitor.c
@@ -115,7 +115,7 @@ static VALUE NIO_Monitor_set_interests(VALUE self, VALUE interests)
     ID interests_id;
 
     if(NIO_Monitor_is_closed(self) == Qtrue) {
-        rb_raise(rb_eTypeError, "monitor is already closed");
+        rb_raise(rb_eEOFError, "monitor is closed");
     }
 
     interests_id = SYM2ID(interests);

--- a/ext/nio4r/monitor.c
+++ b/ext/nio4r/monitor.c
@@ -15,18 +15,22 @@ static void NIO_Monitor_free(struct NIO_Monitor *monitor);
 
 /* Methods */
 static VALUE NIO_Monitor_initialize(VALUE self, VALUE selector, VALUE io, VALUE interests);
-static VALUE NIO_Monitor_set_interests(VALUE self, VALUE interests);
-
 static VALUE NIO_Monitor_close(int argc, VALUE *argv, VALUE self);
 static VALUE NIO_Monitor_is_closed(VALUE self);
 static VALUE NIO_Monitor_io(VALUE self);
 static VALUE NIO_Monitor_interests(VALUE self);
+static VALUE NIO_Monitor_set_interests(VALUE self, VALUE interests);
+static VALUE NIO_Monitor_add_interest(VALUE self, VALUE interest);
 static VALUE NIO_Monitor_selector(VALUE self);
 static VALUE NIO_Monitor_is_readable(VALUE self);
 static VALUE NIO_Monitor_is_writable(VALUE self);
 static VALUE NIO_Monitor_value(VALUE self);
 static VALUE NIO_Monitor_set_value(VALUE self, VALUE obj);
 static VALUE NIO_Monitor_readiness(VALUE self);
+
+/* Internal C functions */
+static int NIO_Monitor_symbol2interest(VALUE interests);
+static void NIO_Monitor_update_interests(VALUE self, int interests);
 
 /* Monitor control how a channel is being waited for by a monitor */
 void Init_NIO_Monitor()
@@ -36,11 +40,12 @@ void Init_NIO_Monitor()
     rb_define_alloc_func(cNIO_Monitor, NIO_Monitor_allocate);
 
     rb_define_method(cNIO_Monitor, "initialize", NIO_Monitor_initialize, 3);
-    rb_define_method(cNIO_Monitor, "interests=", NIO_Monitor_set_interests, 1);
     rb_define_method(cNIO_Monitor, "close", NIO_Monitor_close, -1);
     rb_define_method(cNIO_Monitor, "closed?", NIO_Monitor_is_closed, 0);
     rb_define_method(cNIO_Monitor, "io", NIO_Monitor_io, 0);
     rb_define_method(cNIO_Monitor, "interests", NIO_Monitor_interests, 0);
+    rb_define_method(cNIO_Monitor, "interests=", NIO_Monitor_set_interests, 1);
+    rb_define_method(cNIO_Monitor, "add_interest", NIO_Monitor_add_interest, 1);
     rb_define_method(cNIO_Monitor, "selector", NIO_Monitor_selector, 0);
     rb_define_method(cNIO_Monitor, "value", NIO_Monitor_value, 0);
     rb_define_method(cNIO_Monitor, "value=", NIO_Monitor_set_value, 1);
@@ -109,38 +114,6 @@ static VALUE NIO_Monitor_initialize(VALUE self, VALUE io, VALUE interests, VALUE
     return Qnil;
 }
 
-static VALUE NIO_Monitor_set_interests(VALUE self, VALUE interests)
-{
-    struct NIO_Monitor *monitor;
-    ID interests_id;
-
-    if(NIO_Monitor_is_closed(self) == Qtrue) {
-        rb_raise(rb_eEOFError, "monitor is closed");
-    }
-
-    interests_id = SYM2ID(interests);
-    Data_Get_Struct(self, struct NIO_Monitor, monitor);
-
-    if(interests_id == rb_intern("r")) {
-        monitor->interests = EV_READ;
-    } else if(interests_id == rb_intern("w")) {
-        monitor->interests = EV_WRITE;
-    } else if(interests_id == rb_intern("rw")) {
-        monitor->interests = EV_READ | EV_WRITE;
-    } else {
-        rb_raise(rb_eArgError, "invalid interest type %s (must be :r, :w, or :rw)",
-            RSTRING_PTR(rb_funcall(interests, rb_intern("inspect"), 0, 0)));
-    }
-
-    ev_io_stop(monitor->selector->ev_loop, &monitor->ev_io);
-    ev_io_set(&monitor->ev_io, monitor->ev_io.fd, monitor->interests);
-    ev_io_start(monitor->selector->ev_loop, &monitor->ev_io);
-
-    rb_ivar_set(self, rb_intern("interests"), interests);
-
-    return interests;
-}
-
 static VALUE NIO_Monitor_close(int argc, VALUE *argv, VALUE self)
 {
     VALUE deregister, selector;
@@ -183,6 +156,24 @@ static VALUE NIO_Monitor_io(VALUE self)
 
 static VALUE NIO_Monitor_interests(VALUE self)
 {
+    return rb_ivar_get(self, rb_intern("interests"));
+}
+
+static VALUE NIO_Monitor_set_interests(VALUE self, VALUE interests)
+{
+    NIO_Monitor_update_interests(self, NIO_Monitor_symbol2interest(interests));
+
+    return rb_ivar_get(self, rb_intern("interests"));
+}
+
+static VALUE NIO_Monitor_add_interest(VALUE self, VALUE interest) {
+    int new_interests;
+    struct NIO_Monitor *monitor;
+    Data_Get_Struct(self, struct NIO_Monitor, monitor);
+
+    new_interests = NIO_Monitor_symbol2interest(interest) | monitor->interests;
+    NIO_Monitor_update_interests(self, new_interests);
+
     return rb_ivar_get(self, rb_intern("interests"));
 }
 
@@ -239,4 +230,55 @@ static VALUE NIO_Monitor_is_writable(VALUE self)
     } else {
         return Qfalse;
     }
+}
+
+/* Internal C functions */
+
+static int NIO_Monitor_symbol2interest(VALUE interests)
+{
+    ID interests_id;
+    interests_id = SYM2ID(interests);
+
+    if(interests_id == rb_intern("r")) {
+        return EV_READ;
+    } else if(interests_id == rb_intern("w")) {
+        return EV_WRITE;
+    } else if(interests_id == rb_intern("rw")) {
+        return EV_READ | EV_WRITE;
+    } else {
+        rb_raise(rb_eArgError, "invalid interest type %s (must be :r, :w, or :rw)",
+            RSTRING_PTR(rb_funcall(interests, rb_intern("inspect"), 0, 0)));
+    }
+}
+
+static void NIO_Monitor_update_interests(VALUE self, int interests)
+{
+    ID interests_id;
+    struct NIO_Monitor *monitor;
+    Data_Get_Struct(self, struct NIO_Monitor, monitor);
+
+    if(NIO_Monitor_is_closed(self) == Qtrue) {
+        rb_raise(rb_eEOFError, "monitor is closed");
+    }
+
+    switch(interests) {
+        case EV_READ:
+            interests_id = rb_intern("r");
+            break;
+        case EV_WRITE:
+            interests_id = rb_intern("w");
+            break;
+        case EV_READ | EV_WRITE:
+            interests_id = rb_intern("rw");
+            break;
+        default:
+            rb_raise(rb_eRuntimeError, "bogus NIO_Monitor_update_interests! (%d)", interests);
+    }
+
+    monitor->interests = interests;
+    rb_ivar_set(self, rb_intern("interests"), ID2SYM(interests_id));
+
+    ev_io_stop(monitor->selector->ev_loop, &monitor->ev_io);
+    ev_io_set(&monitor->ev_io, monitor->ev_io.fd, monitor->interests);
+    ev_io_start(monitor->selector->ev_loop, &monitor->ev_io);
 }

--- a/ext/nio4r/org/nio4r/Monitor.java
+++ b/ext/nio4r/org/nio4r/Monitor.java
@@ -41,7 +41,7 @@ public class Monitor extends RubyObject {
     @JRubyMethod(name = "interests=")
     public IRubyObject setInterests(ThreadContext context, IRubyObject interests) {
         if(this.closed == context.getRuntime().getTrue()) {
-            throw context.getRuntime().newTypeError("monitor is already closed");
+            throw context.getRuntime().newEOFError("monitor is closed");
         }
 
         int interestOps = 0;

--- a/ext/nio4r/org/nio4r/Monitor.java
+++ b/ext/nio4r/org/nio4r/Monitor.java
@@ -76,7 +76,23 @@ public class Monitor extends RubyObject {
 
         Ruby ruby = context.getRuntime();
         SelectableChannel channel = (SelectableChannel)io.getChannel();
-        int newInterestOps = Nio4r.symbolToInterestOps(ruby, channel, interest) | key.interestOps();
+        int newInterestOps = key.interestOps() | Nio4r.symbolToInterestOps(ruby, channel, interest);
+
+        key.interestOps(newInterestOps);
+        this.interests = Nio4r.interestOpsToSymbol(ruby, newInterestOps);
+
+        return this.interests;
+    }
+
+    @JRubyMethod(name = "remove_interest")
+    public IRubyObject removeInterest(ThreadContext context, IRubyObject interest) {
+        if(this.closed == context.getRuntime().getTrue()) {
+            throw context.getRuntime().newEOFError("monitor is closed");
+        }
+
+        Ruby ruby = context.getRuntime();
+        SelectableChannel channel = (SelectableChannel)io.getChannel();
+        int newInterestOps = key.interestOps() & ~Nio4r.symbolToInterestOps(ruby, channel, interest);
 
         key.interestOps(newInterestOps);
         this.interests = Nio4r.interestOpsToSymbol(ruby, newInterestOps);

--- a/ext/nio4r/org/nio4r/Monitor.java
+++ b/ext/nio4r/org/nio4r/Monitor.java
@@ -38,36 +38,6 @@ public class Monitor extends RubyObject {
         key.attach(this);
     }
 
-    @JRubyMethod(name = "interests=")
-    public IRubyObject setInterests(ThreadContext context, IRubyObject interests) {
-        if(this.closed == context.getRuntime().getTrue()) {
-            throw context.getRuntime().newEOFError("monitor is closed");
-        }
-
-        int interestOps = 0;
-        Ruby ruby = context.getRuntime();
-        Channel rawChannel = io.getChannel();
-        SelectableChannel channel = (SelectableChannel)rawChannel;
-
-        this.interests = interests;
-
-        if(interests == ruby.newSymbol("r")) {
-            interestOps = SelectionKey.OP_READ;
-        } else if(interests == ruby.newSymbol("w")) {
-            interestOps = SelectionKey.OP_WRITE;
-        } else if(interests == ruby.newSymbol("rw")) {
-            interestOps = SelectionKey.OP_READ|SelectionKey.OP_WRITE;
-        }
-
-        if((interestOps & ~(channel.validOps())) == 0) {
-            key.interestOps(interestOps);
-        } else {
-            throw context.getRuntime().newArgumentError("given interests not supported for this IO object");
-        }
-
-        return this.interests;
-    }
-
     @JRubyMethod
     public IRubyObject io(ThreadContext context) {
         return io;
@@ -78,9 +48,40 @@ public class Monitor extends RubyObject {
         return selector;
     }
 
-    @JRubyMethod
-    public IRubyObject interests(ThreadContext context) {
+    @JRubyMethod(name = "interests")
+    public IRubyObject getInterests(ThreadContext context) {
         return interests;
+    }
+
+    @JRubyMethod(name = "interests=")
+    public IRubyObject setInterests(ThreadContext context, IRubyObject interests) {
+        if(this.closed == context.getRuntime().getTrue()) {
+            throw context.getRuntime().newEOFError("monitor is closed");
+        }
+
+        Ruby ruby = context.getRuntime();
+        SelectableChannel channel = (SelectableChannel)io.getChannel();
+
+        key.interestOps(Nio4r.symbolToInterestOps(ruby, channel, interests));
+        this.interests = interests;
+
+        return this.interests;
+    }
+
+    @JRubyMethod(name = "add_interest")
+    public IRubyObject addInterest(ThreadContext context, IRubyObject interest) {
+        if(this.closed == context.getRuntime().getTrue()) {
+            throw context.getRuntime().newEOFError("monitor is closed");
+        }
+
+        Ruby ruby = context.getRuntime();
+        SelectableChannel channel = (SelectableChannel)io.getChannel();
+        int newInterestOps = Nio4r.symbolToInterestOps(ruby, channel, interest) | key.interestOps();
+
+        key.interestOps(newInterestOps);
+        this.interests = Nio4r.interestOpsToSymbol(ruby, newInterestOps);
+
+        return this.interests;
     }
 
     @JRubyMethod

--- a/ext/nio4r/org/nio4r/Nio4r.java
+++ b/ext/nio4r/org/nio4r/Nio4r.java
@@ -95,6 +95,8 @@ public class Nio4r implements Library {
             case SelectionKey.OP_READ | SelectionKey.OP_CONNECT:
             case SelectionKey.OP_READ | SelectionKey.OP_WRITE:
                 return ruby.newSymbol("rw");
+            case 0:
+                return ruby.getNil();
             default:
                 throw ruby.newArgumentError("unknown interest op combination");
         }

--- a/lib/nio/monitor.rb
+++ b/lib/nio/monitor.rb
@@ -38,7 +38,7 @@ module NIO
 
     # Add new interests to the existing interest set
     #
-    # @param interests [:r, :w, :rw] new I/O interests in (read/write/readwrite)
+    # @param interests [:r, :w, :rw] new I/O interests (read/write/readwrite)
     #
     # @return [self]
     def add_interest(interest)
@@ -59,6 +59,33 @@ module NIO
         end
       when :rw
         @interests = :rw
+      else raise ArgumentError, "bad interests: #{interest}"
+      end
+    end
+
+    # Remove interests from the existing interest set
+    #
+    # @param interests [:r, :w, :rw] I/O interests to remove (read/write/readwrite)
+    #
+    # @return [self]
+    def remove_interest(interest)
+      case interest
+      when :r
+        case @interests
+        when :r  then @interests = nil
+        when :w  then @interests = :w
+        when :rw then @interests = :w
+        when nil then @interests = nil
+        end
+      when :w
+        case @interests
+        when :r  then @interests = :r
+        when :w  then @interests = nil
+        when :rw then @interests = :r
+        when nil then @interests = nil
+        end
+      when :rw
+        @interests = nil
       else raise ArgumentError, "bad interests: #{interest}"
       end
     end

--- a/lib/nio/monitor.rb
+++ b/lib/nio/monitor.rb
@@ -26,7 +26,7 @@ module NIO
 
     # set the interests set
     def interests=(interests)
-      raise TypeError, "monitor is already closed" if closed?
+      raise EOFError, "monitor is closed" if closed?
       raise ArgumentError, "bad interests: #{interests}" unless [:r, :w, :rw].include?(interests)
 
       @interests = interests

--- a/lib/nio/monitor.rb
+++ b/lib/nio/monitor.rb
@@ -24,12 +24,43 @@ module NIO
       @closed    = false
     end
 
-    # set the interests set
+    # Replace the existing interest set with a new one
+    #
+    # @param interests [:r, :w, :rw] I/O readiness we're interested in (read/write/readwrite)
+    #
+    # @return [Symbol] new interests
     def interests=(interests)
       raise EOFError, "monitor is closed" if closed?
       raise ArgumentError, "bad interests: #{interests}" unless [:r, :w, :rw].include?(interests)
 
       @interests = interests
+    end
+
+    # Add new interests to the existing interest set
+    #
+    # @param interests [:r, :w, :rw] new I/O interests in (read/write/readwrite)
+    #
+    # @return [self]
+    def add_interest(interest)
+      case interest
+      when :r
+        case @interests
+        when :r  then @interests = :r
+        when :w  then @interests = :rw
+        when :rw then @interests = :rw
+        when nil then @interests = :r
+        end
+      when :w
+        case @interests
+        when :r  then @interests = :rw
+        when :w  then @interests = :w
+        when :rw then @interests = :rw
+        when nil then @interests = :w
+        end
+      when :rw
+        @interests = :rw
+      else raise ArgumentError, "bad interests: #{interest}"
+      end
     end
 
     # Is the IO object readable?

--- a/spec/nio/monitor_spec.rb
+++ b/spec/nio/monitor_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe NIO::Monitor do
 
     it "raises EOFError if interests are changed after the monitor is closed" do
       monitor.close
-      expect { monitor.interests = :rw }.to raise_error(TypeError) # TODO: EOFError
+      expect { monitor.interests = :rw }.to raise_error(EOFError)
     end
   end
 

--- a/spec/nio/monitor_spec.rb
+++ b/spec/nio/monitor_spec.rb
@@ -63,6 +63,35 @@ RSpec.describe NIO::Monitor do
     end
   end
 
+  describe "#remove_interest" do
+    it "removes an interest from the set" do
+      expect(monitor.interests).to eq(:rw)
+
+      expect(monitor.remove_interest(:r)).to eq(:w)
+      expect(monitor.interests).to eq(:w)
+    end
+
+    it "can clear the last interest" do
+      monitor.interests = :w
+      expect(monitor.interests).to eq(:w)
+
+      expect(monitor.remove_interest(:w)).to be_nil
+      expect(monitor.interests).to be_nil
+    end
+
+    it "acts idempotently" do
+      monitor.interests = :w
+      expect(monitor.interests).to eq(:w)
+
+      expect(monitor.remove_interest(:r)).to eq(:w)
+      expect(monitor.interests).to eq(:w)
+    end
+
+    it "raises ArgumentError if given a bogus option" do
+      expect { monitor.add_interest(:derp) }.to raise_error(ArgumentError)
+    end
+  end
+
   describe "#io" do
     it "knows its IO object" do
       expect(monitor.io).to eq(writer)

--- a/spec/nio/monitor_spec.rb
+++ b/spec/nio/monitor_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe NIO::Monitor do
 
   let(:selector) { NIO::Selector.new }
 
-  subject(:monitor) { selector.register(reader, :r) }
-  subject(:peer)    { selector.register(writer, :rw) }
+  subject(:monitor) { selector.register(writer, :rw) }
+  subject(:peer)    { selector.register(reader, :r) }
 
   before { reader }
   before { writer }
@@ -23,16 +23,16 @@ RSpec.describe NIO::Monitor do
 
   describe "#interests" do
     it "knows its interests" do
-      expect(monitor.interests).to eq(:r)
-      expect(peer.interests).to eq(:rw)
+      expect(peer.interests).to eq(:r)
+      expect(monitor.interests).to eq(:rw)
     end
   end
 
   describe "#interests=" do
     it "changes the interest set" do
-      expect(peer.interests).not_to eq(:w)
-      peer.interests = :w
-      expect(peer.interests).to eq(:w)
+      expect(monitor.interests).not_to eq(:w)
+      monitor.interests = :w
+      expect(monitor.interests).to eq(:w)
     end
 
     it "raises EOFError if interests are changed after the monitor is closed" do
@@ -41,9 +41,31 @@ RSpec.describe NIO::Monitor do
     end
   end
 
+  describe "#add_interest" do
+    it "sets a new interest if it isn't currently registered" do
+      monitor.interests = :r
+      expect(monitor.interests).to eq(:r)
+
+      expect(monitor.add_interest(:w)).to eq(:rw)
+      expect(monitor.interests).to eq(:rw)
+    end
+
+    it "acts idempotently" do
+      monitor.interests = :r
+      expect(monitor.interests).to eq(:r)
+
+      expect(monitor.add_interest(:r)).to eq(:r)
+      expect(monitor.interests).to eq(:r)
+    end
+
+    it "raises ArgumentError if given a bogus option" do
+      expect { monitor.add_interest(:derp) }.to raise_error(ArgumentError)
+    end
+  end
+
   describe "#io" do
     it "knows its IO object" do
-      expect(monitor.io).to eq(reader)
+      expect(monitor.io).to eq(writer)
     end
   end
 
@@ -63,35 +85,35 @@ RSpec.describe NIO::Monitor do
   describe "#readiness" do
     it "knows what operations IO objects are ready for" do
       # For whatever odd reason this breaks unless we eagerly evaluate monitor
-      reader_monitor = monitor
-      writer_monitor = peer
+      reader_peer = peer
+      writer_peer = monitor
 
       selected = selector.select(0)
-      expect(selected).to include(writer_monitor)
+      expect(selected).to include(writer_peer)
 
-      expect(writer_monitor.readiness).to eq(:w)
-      expect(writer_monitor).not_to be_readable
-      expect(writer_monitor).to be_writable
+      expect(writer_peer.readiness).to eq(:w)
+      expect(writer_peer).not_to be_readable
+      expect(writer_peer).to be_writable
 
       writer << "testing 1 2 3"
 
       selected = selector.select(0)
-      expect(selected).to include(reader_monitor)
+      expect(selected).to include(reader_peer)
 
-      expect(reader_monitor.readiness).to eq(:r)
-      expect(reader_monitor).to be_readable
-      expect(reader_monitor).not_to be_writable
+      expect(reader_peer.readiness).to eq(:r)
+      expect(reader_peer).to be_readable
+      expect(reader_peer).not_to be_writable
     end
   end
 
   describe "#close" do
     it "closes" do
       expect(monitor).not_to be_closed
-      expect(selector.registered?(reader)).to be_truthy
+      expect(selector.registered?(writer)).to be_truthy
 
       monitor.close
       expect(monitor).to be_closed
-      expect(selector.registered?(reader)).to be_falsey
+      expect(selector.registered?(writer)).to be_falsey
     end
 
     it "closes even if the selector has been shutdown" do


### PR DESCRIPTION
- Raise EOFError on attempts to change the interests of a closed monitor
- Add new incremental interest change APIs: `#add_interest` and `#remote_interest`