### PR TITLE
[Backport] Update to rubocop 0.46

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ gemspec
 gem "jruby-openssl" if defined? JRUBY_VERSION
 
 group :development, :test do
-  gem "rake-compiler"
-  gem "rspec",   "~> 3",   require: false
-  gem "rubocop", "0.36.0", require: false
   gem "coveralls",         require: false
+  gem "rake-compiler",     require: false
+  gem "rspec",   "~> 3",   require: false
+  gem "rubocop", "0.46.0", require: false
 end

--- a/lib/nio/monitor.rb
+++ b/lib/nio/monitor.rb
@@ -13,7 +13,7 @@ module NIO
           io = io.to_io
         end
 
-        fail TypeError, "can't convert #{io.class} into IO" unless io.is_a? IO
+        raise TypeError, "can't convert #{io.class} into IO" unless io.is_a? IO
       end
 
       @io        = io
@@ -24,8 +24,8 @@ module NIO
 
     # set the interests set
     def interests=(interests)
-      fail TypeError, "monitor is already closed" if closed?
-      fail ArgumentError, "bad interests: #{interests}" unless [:r, :w, :rw].include?(interests)
+      raise TypeError, "monitor is already closed" if closed?
+      raise ArgumentError, "bad interests: #{interests}" unless [:r, :w, :rw].include?(interests)
 
       @interests = interests
     end

--- a/lib/nio/selector.rb
+++ b/lib/nio/selector.rb
@@ -20,10 +20,10 @@ module NIO
     # * :rw - is the IO either readable or writeable?
     def register(io, interest)
       @lock.synchronize do
-        fail IOError, "selector is closed" if closed?
+        raise IOError, "selector is closed" if closed?
 
         monitor = @selectables[io]
-        fail ArgumentError, "already registered as #{monitor.interests.inspect}" if monitor
+        raise ArgumentError, "already registered as #{monitor.interests.inspect}" if monitor
 
         monitor = Monitor.new(io, interest, self)
         @selectables[monitor.io] = monitor
@@ -78,7 +78,7 @@ module NIO
 
         ready_writers.each do |io|
           monitor = @selectables[io]
-          monitor.readiness = (monitor.readiness == :r) ? :rw : :w
+          monitor.readiness = monitor.readiness == :r ? :rw : :w
           selected_monitors << monitor
         end
       end

--- a/spec/nio/monitor_spec.rb
+++ b/spec/nio/monitor_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe NIO::Monitor do
       end
     end
 
-    fail Errno::EADDRINUSE, "couldn't find an open port" unless server
+    raise Errno::EADDRINUSE, "couldn't find an open port" unless server
     client = TCPSocket.new(address, server.addr[1])
     [server, client]
   end


### PR DESCRIPTION
I want to do backport below commit from master to 1-x-stable branch.
https://github.com/socketry/nio4r/commit/f7b7ff1

Because I got an error when I  prepared my development environment for 1-x-stable branch.

Is it possible to merge it?

```
$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]

$ git checkout 1-x-stable

$ bundle install --path vendor/bundle

$ bundle exec rake clean
rake aborted!
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x0055dab4a28c50>
/home/jaruga/git/nio4r/vendor/bundle/ruby/2.4.0/gems/rubocop-0.36.0/lib/rubocop/rake_task.rb:24:in `initialize'
/home/jaruga/git/nio4r/tasks/rubocop.rake:3:in `new'
/home/jaruga/git/nio4r/tasks/rubocop.rake:3:in `<top (required)>'
/home/jaruga/git/nio4r/Rakefile:4:in `load'
/home/jaruga/git/nio4r/Rakefile:4:in `block in <top (required)>'
/home/jaruga/git/nio4r/Rakefile:4:in `each'
/home/jaruga/git/nio4r/Rakefile:4:in `<top (required)>'
/home/jaruga/git/nio4r/vendor/bundle/ruby/2.4.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/usr/local/ruby-2.4.0/bin/bundle:22:in `load'
/usr/local/ruby-2.4.0/bin/bundle:22:in `<main>'
(See full trace by running task with --trace)
```

The reason is because `rubocop` is older.
Though rake-11.0 removes `last_comment`, rubocop-0.36.0 is using it.

```
master
  * rake (12.0.0)
  * rubocop (0.46.0)

1-x-stable
  * rake (12.0.0)
  * rubocop (0.36.0)
```

After patching this, I passed `bundle exec rake compile spec rubocop`.

```
$ bundle exec rake
...
21 files inspected, no offenses detected
```

Thank you.
