### PR TITLE
Add flag NOT to allow compiler to assume the strictest aliasing rules.

### DIFF
--- a/ext/nio4r/extconf.rb
+++ b/ext/nio4r/extconf.rb
@@ -18,6 +18,8 @@ $defs << "-DEV_USE_PORT" if have_header("port.h")
 
 $defs << "-DHAVE_SYS_RESOURCE_H" if have_header("sys/resource.h")
 
+CONFIG["optflags"] << " -fno-strict-aliasing"
+
 dir_config "nio4r_ext"
 create_makefile "nio4r_ext"
 


### PR DESCRIPTION
This PR is not to do strict aliasing optimization for #128 .
