### PR TITLE
Travis: use latest stable jruby-9.1.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ branches:
     - master
 
 rvm:
-  - jruby-9.1.6.0 # latest stable
+  - jruby-9.1.8.0 # latest stable
   - 2.2.2
   - 2.3.3
   - 2.4.0


### PR DESCRIPTION
This PR updates Travis to use latest stable JRuby.