### PR TITLE
Travis: jruby-9.1.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ branches:
     - master
 
 rvm:
-  - jruby-9.1.8.0 # latest stable
+  - jruby-9.1.10.0 # latest stable
   - 2.2.7
   - 2.3.4
   - 2.4.1


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.