### PR TITLE
ext/libev: Update to libev 4.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ to maintain a large codebase.
 Copyright (c) 2011-2017 Tony Arcieri. Distributed under the MIT License.
 See [LICENSE.txt] for further details.
 
-Includes libev 4.23. Copyright (c) 2007-2016 Marc Alexander Lehmann.
+Includes libev 4.24. Copyright (c) 2007-2016 Marc Alexander Lehmann.
 Distributed under the BSD license. See [ext/libev/LICENSE] for details.
 
 [LICENSE.txt]: https://github.com/socketry/nio4r/blob/master/LICENSE.txt

--- a/ext/libev/Changes
+++ b/ext/libev/Changes
@@ -1,5 +1,10 @@
 Revision history for libev, a high-performance and full-featured event loop.
 
+4.24 Wed Dec 28 05:19:55 CET 2016
+	- bump version to 4.24, as the release tarball inexplicably
+          didn't have the right version in ev.h, even though the cvs-tagged
+          version did have the right one (reported by Ales Teska).
+
 4.23 Wed Nov 16 18:23:41 CET 2016
 	- move some declarations at the beginning to help certain retarded
           microsoft compilers, even though their documentation claims

--- a/ext/libev/ev.h
+++ b/ext/libev/ev.h
@@ -211,7 +211,7 @@ struct ev_loop;
 /*****************************************************************************/
 
 #define EV_VERSION_MAJOR 4
-#define EV_VERSION_MINOR 22
+#define EV_VERSION_MINOR 24
 
 /* eventmask, revents, events... */
 enum {


### PR DESCRIPTION
This seems like a procedural version bump with no functionality changes. Update anyway.