### PR TITLE
ext/nio4r: Switch to the libev 4 API

### DIFF
--- a/ext/libev/ev.h
+++ b/ext/libev/ev.h
@@ -56,11 +56,6 @@ EV_CPP(extern "C" {)
 
 /*****************************************************************************/
 
-/* pre-4.0 compatibility */
-#ifndef EV_COMPAT3
-# define EV_COMPAT3 1
-#endif
-
 #ifndef EV_FEATURES
 # if defined __OPTIMIZE_SIZE__
 #  define EV_FEATURES 0x7c

--- a/ext/nio4r/nio4r.h
+++ b/ext/nio4r/nio4r.h
@@ -12,7 +12,7 @@
 
 struct NIO_Selector
 {
-    struct ev_loop *ev_loop;
+    ev_loop *ev_loop;
     struct ev_timer timer; /* for timeouts */
     struct ev_io wakeup;
 

--- a/ext/nio4r/nio4r_ext.c
+++ b/ext/nio4r/nio4r_ext.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2011 Tony Arcieri. Distributed under the MIT License. See
- * LICENSE.txt for further details.
+ * Copyright (c) 2011-2017 Tony Arcieri. Distributed under the MIT License.
+ * See LICENSE.txt for further details.
  */
 
 #include "nio4r.h"

--- a/ext/nio4r/selector.c
+++ b/ext/nio4r/selector.c
@@ -49,8 +49,8 @@ static VALUE NIO_Selector_close_synchronized(VALUE *args);
 static VALUE NIO_Selector_closed_synchronized(VALUE *args);
 
 static int NIO_Selector_run(struct NIO_Selector *selector, VALUE timeout);
-static void NIO_Selector_timeout_callback(struct ev_loop *ev_loop, struct ev_timer *timer, int revents);
-static void NIO_Selector_wakeup_callback(struct ev_loop *ev_loop, struct ev_io *io, int revents);
+static void NIO_Selector_timeout_callback(ev_loop *ev_loop, struct ev_timer *timer, int revents);
+static void NIO_Selector_wakeup_callback(ev_loop *ev_loop, struct ev_io *io, int revents);
 
 /* Default number of slots in the buffer for selected monitors */
 #define INITIAL_READY_BUFFER 32
@@ -455,12 +455,12 @@ static VALUE NIO_Selector_is_empty(VALUE self)
 
 
 /* Called whenever a timeout fires on the event loop */
-static void NIO_Selector_timeout_callback(struct ev_loop *ev_loop, struct ev_timer *timer, int revents)
+static void NIO_Selector_timeout_callback(ev_loop *ev_loop, struct ev_timer *timer, int revents)
 {
 }
 
 /* Called whenever a wakeup request is sent to a selector */
-static void NIO_Selector_wakeup_callback(struct ev_loop *ev_loop, struct ev_io *io, int revents)
+static void NIO_Selector_wakeup_callback(ev_loop *ev_loop, struct ev_io *io, int revents)
 {
     char buffer[128];
     struct NIO_Selector *selector = (struct NIO_Selector *)io->data;
@@ -471,7 +471,7 @@ static void NIO_Selector_wakeup_callback(struct ev_loop *ev_loop, struct ev_io *
 }
 
 /* libev callback fired whenever a monitor gets an event */
-void NIO_Selector_monitor_callback(struct ev_loop *ev_loop, struct ev_io *io, int revents)
+void NIO_Selector_monitor_callback(ev_loop *ev_loop, struct ev_io *io, int revents)
 {
     struct NIO_Monitor *monitor_data = (struct NIO_Monitor *)io->data;
     struct NIO_Selector *selector = monitor_data->selector;


### PR DESCRIPTION
We were previously using the libev 3 compatibility API