### PR TITLE
NIO::Selector: Support for enumerating and configuring backend

### DIFF
--- a/ext/nio4r/nio4r_ext.c
+++ b/ext/nio4r/nio4r_ext.c
@@ -12,6 +12,8 @@ void Init_NIO_ByteBuffer();
 
 void Init_nio4r_ext()
 {
+    ev_set_allocator(xrealloc);
+
     Init_NIO_Selector();
     Init_NIO_Monitor();
     Init_NIO_ByteBuffer();

--- a/ext/nio4r/org/nio4r/Selector.java
+++ b/ext/nio4r/org/nio4r/Selector.java
@@ -30,8 +30,23 @@ public class Selector extends RubyObject {
         super(ruby, rubyClass);
     }
 
+    @JRubyMethod(meta = true)
+    public static IRubyObject backends(ThreadContext context, IRubyObject self) {
+        return context.runtime.newArray(context.runtime.newSymbol("java"));
+    }
+
     @JRubyMethod
     public IRubyObject initialize(ThreadContext context) {
+        initialize(context, context.runtime.newSymbol("java"));
+        return context.nil;
+    }
+
+    @JRubyMethod
+    public IRubyObject initialize(ThreadContext context, IRubyObject backend) {
+        if(backend != context.runtime.newSymbol("java")) {
+            throw context.runtime.newArgumentError(":java is the only supported backend");
+        }
+
         this.cancelledKeys = new HashMap<SelectableChannel,SelectionKey>();
         this.wakeupFired = false;
 

--- a/lib/nio/selector.rb
+++ b/lib/nio/selector.rb
@@ -5,8 +5,17 @@ require "set"
 module NIO
   # Selectors monitor IO objects for events of interest
   class Selector
+    # Return supported backends as symbols
+    #
+    # See `#backend` method definition for all possible backends
+    def self.backends
+      [:ruby]
+    end
+
     # Create a new NIO::Selector
-    def initialize
+    def initialize(backend = :ruby)
+      raise ArgumentError, "unsupported backend: #{backend}" unless backend == :ruby
+
       @selectables = {}
       @lock = Mutex.new
 

--- a/spec/nio/selector_spec.rb
+++ b/spec/nio/selector_spec.rb
@@ -13,6 +13,29 @@ RSpec.describe NIO::Selector do
   let(:reader) { pair.first }
   let(:writer) { pair.last }
 
+  context ".backends" do
+    it "knows all supported backends" do
+      expect(described_class.backends).to be_a Array
+      expect(described_class.backends.first).to be_a Symbol
+    end
+  end
+
+  context "#initialize" do
+    it "allows explicitly specifying a backend" do
+      backend = described_class.backends.first
+      selector = described_class.new(backend)
+      expect(selector.backend).to eq backend
+    end
+
+    it "raises ArgumentError if given an invalid backend" do
+      expect { described_class.new(:derp) }.to raise_error ArgumentError
+    end
+
+    it "raises TypeError if given a non-Symbol parameter" do
+      expect { described_class.new(42).to raise_error TypeError }
+    end
+  end
+
   context "backend" do
     it "knows its backend" do
       expect(subject.backend).to be_a Symbol


### PR DESCRIPTION
* Adds `NIO::Selector.backends` to enumerate supported backends
* Adds an optional parameter to `#initialize` to explicitly choose backend

Example:

```ruby
selector = NIO::Selector.new(:poll)
```