### PR TITLE
Don't build the extension on Windows

### DIFF
--- a/ext/nio4r/extconf.rb
+++ b/ext/nio4r/extconf.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+# Write a dummy Makefile on Windows because we use of the pure ruby implementation
+require "rubygems"
+if Gem.win_platform?
+  File.write("Makefile", "all install::\n")
+  File.write("nio4r_ext.so", "")
+  exit
+end
+
 require "mkmf"
 
 have_header("unistd.h")
@@ -22,14 +30,3 @@ CONFIG["optflags"] << " -fno-strict-aliasing" unless RUBY_PLATFORM =~ /mswin/
 
 dir_config "nio4r_ext"
 create_makefile "nio4r_ext"
-
-# win32 needs to link in "just the right order" for some reason or
-# ioctlsocket will be mapped to an [inverted] ruby specific version.
-if RUBY_PLATFORM =~ /mingw|mswin/
-  makefile_contents = File.read "Makefile"
-
-  makefile_contents.gsub! "DLDFLAGS = ", "DLDFLAGS = -export-all "
-
-  makefile_contents.gsub! "LIBS = $(LIBRUBYARG_SHARED)", "LIBS = -lws2_32 $(LIBRUBYARG_SHARED)"
-  File.open("Makefile", "w") { |f| f.write makefile_contents }
-end


### PR DESCRIPTION
The extension can be build on Windows but it doesn't work. All connection related tests fail. So it's a waste of time to build the extension, which isn't used.

This also removes the patching of the makefile, because it isn't necessary on any recent ruby version, but breaks the extension, so that it can't be loaded by ruby. So this should be removed anyway.

I tested this on ruby-2.2-x86 and 2.4-x64.

See also #161