### PR TITLE
Travis: jruby-9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ branches:
     - master
 
 rvm:
-  - jruby-9.1.12.0 # latest stable
+  - jruby-9.1.13.0 # latest stable
   - 2.2.7
   - 2.3.4
   - 2.4.1


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/09/06/jruby-9-1-13-0.html