### PR TITLE
Travis: jruby-9.1.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ branches:
     - master
 
 rvm:
-  - jruby-9.1.14.0 # latest stable
+  - jruby-9.1.15.0 # latest stable
   - 2.2.7
   - 2.3.4
   - 2.4.1

--- a/spec/nio/selectables/udp_socket_spec.rb
+++ b/spec/nio/selectables/udp_socket_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe UDPSocket do
+RSpec.describe UDPSocket, if: !defined?(JRUBY_VERSION) do
   let(:udp_port) { 23_456 }
 
   let :readable_subject do


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/12/07/jruby-9-1-15-0.html