### PR TITLE
ext/nio4r/extconf.rb: check for port_event_t in port.h (fixes #178)

### DIFF
--- a/ext/nio4r/extconf.rb
+++ b/ext/nio4r/extconf.rb
@@ -14,7 +14,7 @@ have_header("unistd.h")
 
 $defs << "-DEV_USE_SELECT" if have_header("sys/select.h")
 
-$defs << "-DEV_USE_POLL" if have_header("poll.h")
+$defs << "-DEV_USE_POLL" if have_type("port_event_t", "poll.h")
 
 $defs << "-DEV_USE_EPOLL" if have_header("sys/epoll.h")
 


### PR DESCRIPTION
"port.h" is a pretty generic name, and apparently has caused nio4r to fail to build in practice.

Before trying to use it, make sure it contains the types we expect (for Solaris I/O completion ports)