### PR TITLE
Update Rubies to the latest version on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ branches:
 
 rvm:
   - jruby-9.2.0.0 # latest stable
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
-  - 2.5.0
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
   - ruby-head
 
 env:


### PR DESCRIPTION
Right now Below is the latest versions of Ruby. This PR enables to test on the latest version automatically.
2.2.10
2.3.7
2.4.4
2.5.1

