### PR TITLE
Travis: update to jruby-9.2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: ruby
 cache: bundler
-
+dist: xenial
 bundler_args: --without development
 
 rvm:
   - jruby-9.2.5.0 # latest stable
-  - 2.2
   - 2.3
   - 2.4
   - 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: bundler
 bundler_args: --without development
 
 rvm:
-  - jruby-9.2.0.0 # latest stable
+  - jruby-9.2.5.0 # latest stable
   - 2.2
   - 2.3
   - 2.4


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.5.0.

[JRuby 9.2.5.0 release blog post](https://www.jruby.org/2018/12/06/jruby-9-2-5-0.html)