### PR TITLE
Increase size of RSA keys to 2048 bits

### DIFF
--- a/spec/nio/selectables/ssl_socket_spec.rb
+++ b/spec/nio/selectables/ssl_socket_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe OpenSSL::SSL::SSLSocket do
   let(:addr) { "127.0.0.1" }
   let(:port) { next_available_tcp_port }
 
-  let(:ssl_key) { OpenSSL::PKey::RSA.new(1024) }
+  let(:ssl_key) { OpenSSL::PKey::RSA.new(2048) }
 
   let(:ssl_cert) do
     name = OpenSSL::X509::Name.new([%w[CN 127.0.0.1]])


### PR DESCRIPTION
1024 bit keys are considered insecure by newer OpenSSL