### PR TITLE
appveyor.yml - update with Ruby x64 - 2.5, 2.6, & head/trunk

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,27 +1,48 @@
-branches:
-  only:
-    - master
+build: off
+deploy: off
 
 environment:
-  PATH: C:\Ruby%RUBY_VERSION%\DevKit\mingw\bin;C:\Ruby%RUBY_VERSION%\bin;C:\Ruby%RUBY_VERSION%\DevKit\bin;%PATH%
+  PATH: C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  APPVEYOR_SAVE_CACHE_ON_ERROR: True
   matrix:
-  - RUBY_VERSION: "24-x64"
-  - RUBY_VERSION: "23-x64"
-  - RUBY_VERSION: "23"
-  - RUBY_VERSION: "22"
+  - RUBY_VERSION: _trunk
+  - RUBY_VERSION: 26-x64
+  - RUBY_VERSION: 25-x64
+  - RUBY_VERSION: 24-x64
+  - RUBY_VERSION: 23-x64
+  - RUBY_VERSION: 23
+  - RUBY_VERSION: 22
+
+init:
+  - ps: |
+      if ($env:RUBY_VERSION -eq '_trunk') {
+        $trunk_uri = 'https://ci.appveyor.com/api/projects/MSP-Greg/ruby-loco/artifacts/ruby_trunk.7z'
+        (New-Object Net.WebClient).DownloadFile($trunk_uri, 'C:\ruby_trunk.7z')
+        7z.exe x C:\ruby_trunk.7z -oC:\Ruby_trunk
+      }
 
 install:
   - SET RAKEOPT=-rdevkit
+  - ps: |
+      if ($env:RUBY_VERSION -eq '_trunk' -or $env:RUBY_VERSION -ge '23' ) {
+        gem update --system --conservative --no-document
+      } else {
+        gem update --system  2.7.9 --conservative --no-document        
+      }
   - ruby -v
   - gem -v
   - bundle -v
-  - bundle install
-
-build: off
-
-before_build:
-  - gem update --system
+  - bundle install --path vendor\bundle
 
 test_script:
-  - echo %PATH%
   - bundle exec rake spec
+
+matrix:
+  allow_failures:
+    - RUBY_VERSION: _trunk
+    - RUBY_VERSION: 26-x64
+    - RUBY_VERSION: 25-x64
+
+cache:
+  # If one of the files after the right arrow changes, cache will be invalidated
+  - vendor\bundle -> appveyor.yml, Gemfile, nio4r.gemspec


### PR DESCRIPTION
update appveyor.yml:

1. Add Ruby 25-x64, 26-x64 & trunk/head x64.
2. Add caching for bundle install
3. Remove path console output
4. Remove branch restriction, makes it difficult to test in one's fork

See https://ci.appveyor.com/project/MSP-Greg/nio4r/builds/23409405 for a build. With cache, it takes about 5 minutes.


