### PR TITLE
Skip IO.try_convert in ruby code for SSL Sockets

### DIFF
--- a/lib/nio/monitor.rb
+++ b/lib/nio/monitor.rb
@@ -8,14 +8,16 @@ module NIO
 
     # :nodoc
     def initialize(io, interests, selector)
-      unless io.is_a?(IO)
-        if IO.respond_to? :try_convert
-          io = IO.try_convert(io)
-        elsif io.respond_to? :to_io
-          io = io.to_io
-        end
+      unless io.is_a? OpenSSL::SSL::SSLSocket
+        unless io.is_a?(IO)
+          if IO.respond_to? :try_convert
+            io = IO.try_convert(io)
+          elsif io.respond_to? :to_io
+            io = io.to_io
+          end
 
-        raise TypeError, "can't convert #{io.class} into IO" unless io.is_a? IO
+          raise TypeError, "can't convert #{io.class} into IO" unless io.is_a? IO
+        end
       end
 
       @io        = io

--- a/lib/nio/selector.rb
+++ b/lib/nio/selector.rb
@@ -44,7 +44,9 @@ module NIO
     # * :w - is the IO writeable?
     # * :rw - is the IO either readable or writeable?
     def register(io, interest)
-      io = IO.try_convert(io)
+      unless io.is_a? OpenSSL::SSL::SSLSocket
+        io = IO.try_convert(io)
+      end
 
       @lock.synchronize do
         raise IOError, "selector is closed" if closed?


### PR DESCRIPTION
When using SSL sockets, in the c extension code, monitor.io is an SSLSocket, but in Ruby code, monitor.io is a TCPSocket.