### PR TITLE
monitor.rb :nodoc => :nodoc: [skip ci]

### DIFF
--- a/lib/nio/monitor.rb
+++ b/lib/nio/monitor.rb
@@ -6,7 +6,7 @@ module NIO
     attr_reader :io, :interests, :selector
     attr_accessor :value, :readiness
 
-    # :nodoc
+    # :nodoc:
     def initialize(io, interests, selector)
       unless io.is_a? OpenSSL::SSL::SSLSocket
         unless io.is_a?(IO)


### PR DESCRIPTION
monitor.rb currently has the following comment with `:nodoc`

https://github.com/socketry/nio4r/blob/4dc00962f95d2e900a1c5bbde773410aa9d0ade2/lib/nio/monitor.rb#L1-L10

I believe at one point RDoc accepted that, but [current docs](https://msp-greg.github.io/ruby_trunk/rdoc/RDoc/Markup.html#label-Directives) for it show `:nodoc:`.  Commit updates only that comment line.

See docs shown at https://msp-greg.github.io/nio4r/
