### PR TITLE
Set TRUFFLERUBY_RECOMPILE_OPENSSL to workaround OpenSSL issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ matrix:
     - rvm: 2.6
       os: osx
     - rvm: truffleruby
+      env: TRUFFLERUBY_RECOMPILE_OPENSSL=true
     - rvm: truffleruby
-      env: NIO4R_PURE=true
+      env: TRUFFLERUBY_RECOMPILE_OPENSSL=true NIO4R_PURE=true
     - rvm: jruby
       env: JRUBY_OPTS="--debug -X+O --dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
     - rvm: jruby-head


### PR DESCRIPTION
* See https://github.com/oracle/truffleruby/issues/1676