### PR TITLE
Travis: add testing on OpenSSL 1.0.1 (trusty) & 1.1.1 (bionic & osx) [skip appveyor]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: ruby
 cache: bundler
 dist: xenial
+env: OS="xenial 16.04"
 bundler_args: --without development
+
+after_script:
+  - ruby -ropenssl -e "puts ENV['OS'], RUBY_DESCRIPTION, OpenSSL::OPENSSL_LIBRARY_VERSION"
 
 matrix:
   fast_finish: true
@@ -12,8 +16,19 @@ matrix:
     - rvm: 2.6
       env: NIO4R_PURE=true
     - rvm: 2.6
+    - rvm: 2.3
+      dist: trusty
+      env: OS="trusty 14.04"
+    - rvm: 2.6.3
+      dist: bionic
+      env: OS="bionic 18.04"
     - rvm: 2.6
       os: osx
+      env: OS="osx"
+    - rvm: 2.4.6
+      os: osx
+      osx_image: xcode10.2
+      env: OS="osx xcode 10.2"
     - rvm: truffleruby
     - rvm: truffleruby
       env: NIO4R_PURE=true


### PR DESCRIPTION
As of 2019-07-07, below is the Travis 'must pass' matrix.  New jobs added by the PR are noted, along with their OpenSSL version.

1. Only three jobs were added, two use OpenSSL 1.1.1, one uses 1.0.1.   More Ruby versions could be added, I kept it to a minimum.

2. Added an 'after_script' command that shows os info, Ruby version, & OpenSSL version.  Travis collapses it...

```
                            OpenSSL
MATRIX                      version

- rvm: 2.3                    1.0.2
- rvm: 2.4
- rvm: 2.5
- rvm: 2.6
  env: NIO4R_PURE=true
- rvm: 2.6

- rvm: 2.3                    1.0.1   (added by PR)
  dist: trusty
  env: OS="trusty 14.04"

- rvm: 2.6.3                  1.1.1   (added by PR)
  dist: bionic
  env: OS="bionic 18.04"

- rvm: 2.6                    1.1.0
  os: osx
  env: OS="osx"

- rvm: 2.4.6                  1.1.1   (added by PR)
  os: osx
  osx_image: xcode10.2
  env: OS="osx xcode 10.2"
```