### PR TITLE
Allow calling `deregister` on closed IO objects

### DIFF
--- a/ext/nio4r/org/nio4r/Selector.java
+++ b/ext/nio4r/org/nio4r/Selector.java
@@ -137,10 +137,10 @@ public class Selector extends RubyObject {
     @JRubyMethod
     public IRubyObject deregister(ThreadContext context, IRubyObject io) {
         Ruby runtime = context.getRuntime();
-        OpenFile f = RubyIO.convertToIO(context, io).getOpenFileInitialized();
-        if (f.fd() == null)
+        OpenFile file = RubyIO.convertToIO(context, io).getOpenFileInitialized();
+        if (file.fd() == null)
             return context.nil;
-        Channel rawChannel = f.channel();
+        Channel rawChannel = file.channel();
 
         if(!(rawChannel instanceof SelectableChannel)) {
             throw runtime.newArgumentError("not a selectable IO object");

--- a/ext/nio4r/org/nio4r/Selector.java
+++ b/ext/nio4r/org/nio4r/Selector.java
@@ -19,6 +19,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.io.OpenFile;
 
 import org.nio4r.Monitor;
 
@@ -136,7 +137,10 @@ public class Selector extends RubyObject {
     @JRubyMethod
     public IRubyObject deregister(ThreadContext context, IRubyObject io) {
         Ruby runtime = context.getRuntime();
-        Channel rawChannel = RubyIO.convertToIO(context, io).getChannel();
+        OpenFile f = RubyIO.convertToIO(context, io).getOpenFileInitialized();
+        if (f.fd() == null)
+            return context.nil;
+        Channel rawChannel = f.channel();
 
         if(!(rawChannel instanceof SelectableChannel)) {
             throw runtime.newArgumentError("not a selectable IO object");

--- a/spec/nio/selector_spec.rb
+++ b/spec/nio/selector_spec.rb
@@ -67,6 +67,15 @@ RSpec.describe NIO::Selector do
     expect(monitor).to be_closed
   end
 
+  it "allows deregistering closed IO objects" do
+    subject.register(reader, :r)
+    reader.close
+
+    expect do
+      subject.deregister(reader)
+    end.not_to raise_error
+  end
+
   it "reports if it is empty" do
     expect(subject).to be_empty
     subject.register(reader, :r)


### PR DESCRIPTION
Only JRuby would throw an exception when trying to deregister a closed
stream. With this patch, JRuby's implementation will behave just like
the other platforms.

Closes #215.