### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/nio4r.gemspec
+++ b/nio4r.gemspec
@@ -20,6 +20,14 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.version       = NIO::VERSION
 
+  spec.metadata = {
+    "bug_tracker_uri"   => "https://github.com/socketry/nio4r/issues",
+    "changelog_uri"     => "https://github.com/socketry/nio4r/blob/master/CHANGES.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/nio4r/#{spec.version}",
+    "source_code_uri"   => "https://github.com/socketry/nio4r/tree/v#{spec.version}",
+    "wiki_uri"          => "https://github.com/socketry/nio4r/wiki"
+  }
+
   spec.required_ruby_version = ">= 2.3"
 
   if defined? JRUBY_VERSION


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `wiki_uri` and `source_code_uri` links will appear on the rubygems page at https://rubygems.org/gems/nio4r and be available via the rubygems API after the next release.