### PR TITLE
Polish examples/echo_server.rb

### DIFF
--- a/examples/echo_server.rb
+++ b/examples/echo_server.rb
@@ -19,7 +19,7 @@ class EchoServer
 
   def run
     loop do
-      @selector.select { |monitor| monitor.value.call(monitor) }
+      @selector.select { |monitor| monitor.value.call }
     end
   end
 


### PR DESCRIPTION
```ruby
  def run
    loop do
      @selector.select { |monitor| monitor.value.call(monitor) }
    end
  end
```
The argument `monitor` seems useless.