### PR TITLE
Bump rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ Style/IfUnlessModifier:
 # Lint
 #
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: false
 
 Lint/Loop:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   DisplayCopNames: true
 
 Layout/HashAlignment:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,9 @@ Layout/HashAlignment:
 Layout/LineLength:
   Max: 128
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: false
+
 Layout/SpaceInsideBlockBraces:
   Enabled: false
 
@@ -24,6 +27,11 @@ Lint/SuppressedException:
 Lint/Loop:
   Enabled: false
 
+Lint/RaiseException:
+  Enabled: false
+
+Lint/StructNewOverride:
+  Enabled: false
 #
 # Metrics
 #
@@ -52,6 +60,9 @@ Metrics/PerceivedComplexity:
 # Style
 #
 
+Style/ExponentialNotation:
+  Enabled: false
+
 Style/FormatStringToken:
   Enabled: false
 
@@ -59,6 +70,15 @@ Style/FrozenStringLiteralComment:
   Enabled: true
 
 Style/GlobalVars:
+  Enabled: false
+
+Style/HashEachMethods:
+  Enabled: false
+
+Style/HashTransformKeys:
+  Enabled: false
+
+Style/HashTransformValues:
   Enabled: false
 
 Style/NumericPredicate:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ Layout/SpaceInsideBlockBraces:
 Style/IfUnlessModifier:
   Enabled: false
 
+Style/UnpackFirst:
+  Enabled: false
+
 #
 # Lint
 #

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ AllCops:
 Layout/HashAlignment:
   Enabled: false
 
+Layout/LineLength:
+  Max: 128
+
 Layout/SpaceInsideBlockBraces:
   Enabled: false
 
@@ -33,9 +36,6 @@ Metrics/BlockLength:
   Enabled: false
 
 Metrics/ClassLength:
-  Max: 128
-
-Metrics/LineLength:
   Max: 128
 
 Metrics/MethodLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ AllCops:
   TargetRubyVersion: 2.3
   DisplayCopNames: true
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 Layout/SpaceInsideBlockBraces:

--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ group :development, :test do
   gem "coveralls", require: false
   gem "rake-compiler", require: false
   gem "rspec", "~> 3.7", require: false
-  gem "rubocop", "0.74.0", require: false
+  gem "rubocop", "0.82.0", require: false
 end

--- a/nio4r.gemspec
+++ b/nio4r.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
     "wiki_uri"          => "https://github.com/socketry/nio4r/wiki"
   }
 
-  spec.required_ruby_version = ">= 2.3"
+  spec.required_ruby_version = ">= 2.4"
 
   if defined? JRUBY_VERSION
     spec.files << "lib/nio4r_ext.jar"


### PR DESCRIPTION
Hi, I hope you guys are doing well.

I saw the opportunity to update rubocop in this project. What do you think?

This all started when, after running rubocop, I received the following warnings:


```
Error: The `Layout/AlignHash` cop has been renamed to `Layout/HashAlignment`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Lint/HandleExceptions` cop has been renamed to `Lint/SuppressedException`.
(obsolete configuration found in .rubocop.yml, please update it)
```


About this PR:

- Bumb Rubocop to 0.82
- Update ruby version to 2.4, Version 2.3 is no longer supported for this rubocop version. Just a suggestion.
- Fix rubocop warnings.