### PR TITLE
Fix use when OpenSSL is not loaded

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, macos, windows-latest]
+        os: [ubuntu-16.04, ubuntu-18.04, macos-latest, windows-latest]
         ruby: [2.4, 2.5, 2.6, 2.7, jruby, truffleruby-head]
         exclude:
           - { os: windows-latest, ruby: jruby }

--- a/lib/nio/monitor.rb
+++ b/lib/nio/monitor.rb
@@ -8,7 +8,7 @@ module NIO
 
     # :nodoc:
     def initialize(io, interests, selector)
-      unless io.is_a? OpenSSL::SSL::SSLSocket
+      unless defined?(::OpenSSL) && io.is_a?(::OpenSSL::SSL::SSLSocket)
         unless io.is_a?(IO)
           if IO.respond_to? :try_convert
             io = IO.try_convert(io)

--- a/lib/nio/selector.rb
+++ b/lib/nio/selector.rb
@@ -44,7 +44,7 @@ module NIO
     # * :w - is the IO writeable?
     # * :rw - is the IO either readable or writeable?
     def register(io, interest)
-      unless io.is_a? OpenSSL::SSL::SSLSocket
+      unless defined?(::OpenSSL) && io.is_a?(::OpenSSL::SSL::SSLSocket)
         io = IO.try_convert(io)
       end
 

--- a/spec/nio/selectables/ssl_socket_spec.rb
+++ b/spec/nio/selectables/ssl_socket_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "openssl"
 
 RSpec.describe OpenSSL::SSL::SSLSocket do
+
+  require "openssl"
+
   before(:all) do
     @tls = []
   end


### PR DESCRIPTION
Currently, errors are raised if OpenSSL is not loaded.  Fixed, along with small spec change.

JFYI, I benchmarked `defined?` vs `Object.const_defined?`, and, most of the time, `defined?` was a little faster.  Only tested on Windows mingw, 2.2 & head.

For GitHub Actions `runs-on:`, seems to prefer 'macos-latest', current workflow used 'macos'.  Changed so CI passes on macOS MRI.

Closes https://github.com/socketry/nio4r/issues/238