### PR TITLE
Quick (possible) fix for #241 + consistent global C formatting / styling

### DIFF
--- a/ext/nio4r/.clang-format
+++ b/ext/nio4r/.clang-format
@@ -1,0 +1,17 @@
+---
+Language:        Cpp
+BasedOnStyle:  WebKit
+AllowAllParametersOfDeclarationOnNextLine: false
+BinPackArguments: false
+BinPackParameters: false
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: true
+BreakBeforeBraces: Mozilla
+IndentCaseLabels: true
+# BraceWrapping:
+#   AfterControlStatement: Never
+PointerAlignment: Right
+SpaceBeforeParens: Never
+IndentWidth: 4
+...
+

--- a/ext/nio4r/bytebuffer.c
+++ b/ext/nio4r/bytebuffer.c
@@ -1,8 +1,8 @@
 #include "nio4r.h"
 
-static VALUE mNIO = Qnil;
-static VALUE cNIO_ByteBuffer = Qnil;
-static VALUE cNIO_ByteBuffer_OverflowError = Qnil;
+static VALUE mNIO                           = Qnil;
+static VALUE cNIO_ByteBuffer                = Qnil;
+static VALUE cNIO_ByteBuffer_OverflowError  = Qnil;
 static VALUE cNIO_ByteBuffer_UnderflowError = Qnil;
 static VALUE cNIO_ByteBuffer_MarkUnsetError = Qnil;
 
@@ -38,7 +38,7 @@ static VALUE NIO_ByteBuffer_inspect(VALUE self);
 
 void Init_NIO_ByteBuffer()
 {
-    mNIO = rb_define_module("NIO");
+    mNIO            = rb_define_module("NIO");
     cNIO_ByteBuffer = rb_define_class_under(mNIO, "ByteBuffer", rb_cObject);
     rb_define_alloc_func(cNIO_ByteBuffer, NIO_ByteBuffer_allocate);
 
@@ -75,7 +75,7 @@ void Init_NIO_ByteBuffer()
 static VALUE NIO_ByteBuffer_allocate(VALUE klass)
 {
     struct NIO_ByteBuffer *bytebuffer = (struct NIO_ByteBuffer *)xmalloc(sizeof(struct NIO_ByteBuffer));
-    bytebuffer->buffer = NULL;
+    bytebuffer->buffer                = NULL;
     return Data_Wrap_Struct(klass, NIO_ByteBuffer_gc_mark, NIO_ByteBuffer_free, bytebuffer);
 }
 
@@ -86,7 +86,7 @@ static void NIO_ByteBuffer_gc_mark(struct NIO_ByteBuffer *buffer)
 static void NIO_ByteBuffer_free(struct NIO_ByteBuffer *buffer)
 {
     if(buffer->buffer)
-      xfree(buffer->buffer);
+        xfree(buffer->buffer);
     xfree(buffer);
 }
 
@@ -96,7 +96,7 @@ static VALUE NIO_ByteBuffer_initialize(VALUE self, VALUE capacity)
     Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
 
     buffer->capacity = NUM2INT(capacity);
-    buffer->buffer = xmalloc(buffer->capacity);
+    buffer->buffer   = xmalloc(buffer->capacity);
 
     NIO_ByteBuffer_clear(self);
 
@@ -111,8 +111,8 @@ static VALUE NIO_ByteBuffer_clear(VALUE self)
     memset(buffer->buffer, 0, buffer->capacity);
 
     buffer->position = 0;
-    buffer->limit = buffer->capacity;
-    buffer->mark = MARK_UNSET;
+    buffer->limit    = buffer->capacity;
+    buffer->mark     = MARK_UNSET;
 
     return self;
 }
@@ -343,9 +343,9 @@ static VALUE NIO_ByteBuffer_flip(VALUE self)
     struct NIO_ByteBuffer *buffer;
     Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
 
-    buffer->limit = buffer->position;
+    buffer->limit    = buffer->position;
     buffer->position = 0;
-    buffer->mark = MARK_UNSET;
+    buffer->mark     = MARK_UNSET;
 
     return self;
 }
@@ -356,7 +356,7 @@ static VALUE NIO_ByteBuffer_rewind(VALUE self)
     Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
 
     buffer->position = 0;
-    buffer->mark = MARK_UNSET;
+    buffer->mark     = MARK_UNSET;
 
     return self;
 }
@@ -391,7 +391,7 @@ static VALUE NIO_ByteBuffer_compact(VALUE self)
 
     memmove(buffer->buffer, buffer->buffer + buffer->position, buffer->limit - buffer->position);
     buffer->position = buffer->limit - buffer->position;
-    buffer->limit = buffer->capacity;
+    buffer->limit    = buffer->capacity;
 
     return self;
 }
@@ -421,9 +421,8 @@ static VALUE NIO_ByteBuffer_inspect(VALUE self)
     return rb_sprintf(
         "#<%s:%p @position=%d @limit=%d @capacity=%d>",
         rb_class2name(CLASS_OF(self)),
-        (void*)self,
+        (void *)self,
         buffer->position,
         buffer->limit,
-        buffer->capacity
-    );
+        buffer->capacity);
 }

--- a/ext/nio4r/libev.h
+++ b/ext/nio4r/libev.h
@@ -2,8 +2,8 @@
 
 #ifdef _WIN32
 #define EV_SELECT_IS_WINSOCKET 1
-#define EV_USE_MONOTONIC 0
-#define EV_USE_REALTIME 0
+#define EV_USE_MONOTONIC       0
+#define EV_USE_REALTIME        0
 #endif
 
 #include "../libev/ev.h"

--- a/ext/nio4r/monitor.c
+++ b/ext/nio4r/monitor.c
@@ -66,6 +66,7 @@ static VALUE NIO_Monitor_allocate(VALUE klass)
 
 static void NIO_Monitor_mark(struct NIO_Monitor *monitor)
 {
+    rb_gc_mark(monitor->self); /* so GC won't move our reference to self */
 }
 
 static void NIO_Monitor_free(struct NIO_Monitor *monitor)

--- a/ext/nio4r/monitor.c
+++ b/ext/nio4r/monitor.c
@@ -5,7 +5,7 @@
 
 #include "nio4r.h"
 
-static VALUE mNIO = Qnil;
+static VALUE mNIO         = Qnil;
 static VALUE cNIO_Monitor = Qnil;
 
 /* Allocator/deallocator */
@@ -36,7 +36,7 @@ static void NIO_Monitor_update_interests(VALUE self, int interests);
 /* Monitor control how a channel is being waited for by a monitor */
 void Init_NIO_Monitor()
 {
-    mNIO = rb_define_module("NIO");
+    mNIO         = rb_define_module("NIO");
     cNIO_Monitor = rb_define_class_under(mNIO, "Monitor", rb_cObject);
     rb_define_alloc_func(cNIO_Monitor, NIO_Monitor_allocate);
 
@@ -91,8 +91,7 @@ static VALUE NIO_Monitor_initialize(VALUE self, VALUE io, VALUE interests, VALUE
     } else if(interests_id == rb_intern("rw")) {
         monitor->interests = EV_READ | EV_WRITE;
     } else {
-        rb_raise(rb_eArgError, "invalid event type %s (must be :r, :w, or :rw)",
-            RSTRING_PTR(rb_funcall(interests, rb_intern("inspect"), 0)));
+        rb_raise(rb_eArgError, "invalid event type %s (must be :r, :w, or :rw)", RSTRING_PTR(rb_funcall(interests, rb_intern("inspect"), 0)));
     }
 
     GetOpenFile(rb_convert_type(io, T_FILE, "IO", "to_io"), fptr);
@@ -104,15 +103,15 @@ static VALUE NIO_Monitor_initialize(VALUE self, VALUE io, VALUE interests, VALUE
 
     Data_Get_Struct(selector_obj, struct NIO_Selector, selector);
 
-    monitor->self = self;
+    monitor->self       = self;
     monitor->ev_io.data = (void *)monitor;
 
     /* We can safely hang onto this as we also hang onto a reference to the
        object where it originally came from */
     monitor->selector = selector;
 
-    if (monitor->interests) {
-      ev_io_start(selector->ev_loop, &monitor->ev_io);
+    if(monitor->interests) {
+        ev_io_start(selector->ev_loop, &monitor->ev_io);
     }
 
     return Qnil;
@@ -130,12 +129,12 @@ static VALUE NIO_Monitor_close(int argc, VALUE *argv, VALUE self)
     if(selector != Qnil) {
         /* if ev_loop is 0, it means that the loop has been stopped already (see NIO_Selector_shutdown) */
         if(monitor->interests && monitor->selector->ev_loop) {
-          ev_io_stop(monitor->selector->ev_loop, &monitor->ev_io);
+            ev_io_stop(monitor->selector->ev_loop, &monitor->ev_io);
         }
 
         monitor->selector = 0;
         rb_ivar_set(self, rb_intern("selector"), Qnil);
-    
+
         /* Default value is true */
         if(deregister == Qtrue || deregister == Qnil) {
             rb_funcall(selector, rb_intern("deregister"), 1, rb_ivar_get(self, rb_intern("io")));
@@ -174,7 +173,8 @@ static VALUE NIO_Monitor_set_interests(VALUE self, VALUE interests)
     return rb_ivar_get(self, rb_intern("interests"));
 }
 
-static VALUE NIO_Monitor_add_interest(VALUE self, VALUE interest) {
+static VALUE NIO_Monitor_add_interest(VALUE self, VALUE interest)
+{
     struct NIO_Monitor *monitor;
     Data_Get_Struct(self, struct NIO_Monitor, monitor);
 
@@ -184,7 +184,8 @@ static VALUE NIO_Monitor_add_interest(VALUE self, VALUE interest) {
     return rb_ivar_get(self, rb_intern("interests"));
 }
 
-static VALUE NIO_Monitor_remove_interest(VALUE self, VALUE interest) {
+static VALUE NIO_Monitor_remove_interest(VALUE self, VALUE interest)
+{
     struct NIO_Monitor *monitor;
     Data_Get_Struct(self, struct NIO_Monitor, monitor);
 
@@ -263,8 +264,7 @@ static int NIO_Monitor_symbol2interest(VALUE interests)
     } else if(interests_id == rb_intern("rw")) {
         return EV_READ | EV_WRITE;
     } else {
-        rb_raise(rb_eArgError, "invalid interest type %s (must be :r, :w, or :rw)",
-            RSTRING_PTR(rb_funcall(interests, rb_intern("inspect"), 0)));
+        rb_raise(rb_eArgError, "invalid interest type %s (must be :r, :w, or :rw)", RSTRING_PTR(rb_funcall(interests, rb_intern("inspect"), 0)));
     }
 }
 

--- a/ext/nio4r/nio4r.h
+++ b/ext/nio4r/nio4r.h
@@ -7,8 +7,9 @@
 #define NIO4R_H
 
 #include "ruby.h"
-#include "ruby/io.h"
+
 #include "libev.h"
+#include "ruby/io.h"
 
 struct NIO_Selector
 {
@@ -44,11 +45,10 @@ struct NIO_ByteBuffer
     int position, limit, capacity, mark;
 };
 
-
 #ifdef GetReadFile
-# define FPTR_TO_FD(fptr) (fileno(GetReadFile(fptr)))
+#define FPTR_TO_FD(fptr) (fileno(GetReadFile(fptr)))
 #else
-# define FPTR_TO_FD(fptr) fptr->fd
+#define FPTR_TO_FD(fptr) fptr->fd
 #endif /* GetReadFile */
 
 /* Thunk between libev callbacks in NIO::Monitors and NIO::Selectors */

--- a/ext/nio4r/nio4r_ext.c
+++ b/ext/nio4r/nio4r_ext.c
@@ -4,6 +4,7 @@
  */
 
 #include "nio4r.h"
+
 #include "../libev/ev.c"
 
 void Init_NIO_Selector();

--- a/ext/nio4r/selector.c
+++ b/ext/nio4r/selector.c
@@ -5,7 +5,7 @@
 
 #include "nio4r.h"
 #ifdef HAVE_RUBYSIG_H
-# include "rubysig.h"
+#include "rubysig.h"
 #endif
 
 #ifdef HAVE_UNISTD_H
@@ -14,10 +14,10 @@
 #include <io.h>
 #endif
 
-#include <fcntl.h>
 #include <assert.h>
+#include <fcntl.h>
 
-static VALUE mNIO = Qnil;
+static VALUE mNIO          = Qnil;
 static VALUE cNIO_Monitor  = Qnil;
 static VALUE cNIO_Selector = Qnil;
 
@@ -64,7 +64,7 @@ static void NIO_Selector_wakeup_callback(struct ev_loop *ev_loop, struct ev_io *
 /* Selectors wait for events */
 void Init_NIO_Selector()
 {
-    mNIO = rb_define_module("NIO");
+    mNIO          = rb_define_module("NIO");
     cNIO_Selector = rb_define_class_under(mNIO, "Selector", rb_cObject);
     rb_define_alloc_func(cNIO_Selector, NIO_Selector_allocate);
 
@@ -80,7 +80,7 @@ void Init_NIO_Selector()
     rb_define_method(cNIO_Selector, "closed?", NIO_Selector_closed, 0);
     rb_define_method(cNIO_Selector, "empty?", NIO_Selector_is_empty, 0);
 
-    cNIO_Monitor = rb_define_class_under(mNIO, "Monitor",  rb_cObject);
+    cNIO_Monitor = rb_define_class_under(mNIO, "Monitor", rb_cObject);
 }
 
 /* Create the libev event loop and incoming event buffer */
@@ -100,8 +100,7 @@ static VALUE NIO_Selector_allocate(VALUE klass)
     }
 
     /* Use non-blocking reads/writes during wakeup, in case the buffer is full */
-    if(fcntl(fds[0], F_SETFL, O_NONBLOCK) < 0 ||
-       fcntl(fds[1], F_SETFL, O_NONBLOCK) < 0) {
+    if(fcntl(fds[0], F_SETFL, O_NONBLOCK) < 0 || fcntl(fds[1], F_SETFL, O_NONBLOCK) < 0) {
         rb_sys_fail("fcntl");
     }
 
@@ -119,7 +118,7 @@ static VALUE NIO_Selector_allocate(VALUE klass)
     selector->wakeup.data = (void *)selector;
 
     selector->closed = selector->selecting = selector->wakeup_fired = selector->ready_count = 0;
-    selector->ready_array = Qnil;
+    selector->ready_array                                                                   = Qnil;
 
     return Data_Wrap_Struct(klass, NIO_Selector_mark, NIO_Selector_free, selector);
 }
@@ -159,9 +158,10 @@ static void NIO_Selector_free(struct NIO_Selector *selector)
 }
 
 /* Return an array of symbols for supported backends */
-static VALUE NIO_Selector_supported_backends(VALUE klass) {
+static VALUE NIO_Selector_supported_backends(VALUE klass)
+{
     unsigned int backends = ev_supported_backends();
-    VALUE result = rb_ary_new();
+    VALUE result          = rb_ary_new();
 
     if(backends & EVBACKEND_EPOLL) {
         rb_ary_push(result, ID2SYM(rb_intern("epoll")));
@@ -203,8 +203,7 @@ static VALUE NIO_Selector_initialize(int argc, VALUE *argv, VALUE self)
 
     if(backend != Qnil) {
         if(!rb_ary_includes(NIO_Selector_supported_backends(CLASS_OF(self)), backend)) {
-            rb_raise(rb_eArgError, "unsupported backend: %s",
-                RSTRING_PTR(rb_funcall(backend, rb_intern("inspect"), 0)));
+            rb_raise(rb_eArgError, "unsupported backend: %s", RSTRING_PTR(rb_funcall(backend, rb_intern("inspect"), 0)));
         }
 
         backend_id = SYM2ID(backend);
@@ -220,8 +219,7 @@ static VALUE NIO_Selector_initialize(int argc, VALUE *argv, VALUE self)
         } else if(backend_id == rb_intern("port")) {
             flags = EVBACKEND_PORT;
         } else {
-            rb_raise(rb_eArgError, "unsupported backend: %s",
-                RSTRING_PTR(rb_funcall(backend, rb_intern("inspect"), 0)));
+            rb_raise(rb_eArgError, "unsupported backend: %s", RSTRING_PTR(rb_funcall(backend, rb_intern("inspect"), 0)));
         }
     }
 
@@ -245,7 +243,8 @@ static VALUE NIO_Selector_initialize(int argc, VALUE *argv, VALUE self)
     return Qnil;
 }
 
-static VALUE NIO_Selector_backend(VALUE self) {
+static VALUE NIO_Selector_backend(VALUE self)
+{
     struct NIO_Selector *selector;
 
     Data_Get_Struct(self, struct NIO_Selector, selector);
@@ -253,7 +252,7 @@ static VALUE NIO_Selector_backend(VALUE self) {
         rb_raise(rb_eIOError, "selector is closed");
     }
 
-    switch (ev_backend(selector->ev_loop)) {
+    switch(ev_backend(selector->ev_loop)) {
         case EVBACKEND_EPOLL:
             return ID2SYM(rb_intern("epoll"));
         case EVBACKEND_POLL:
@@ -275,7 +274,7 @@ static VALUE NIO_Selector_synchronize(VALUE self, VALUE (*func)(VALUE *args), VA
     VALUE current_thread, lock_holder, lock;
 
     current_thread = rb_thread_current();
-    lock_holder = rb_ivar_get(self, rb_intern("lock_holder"));
+    lock_holder    = rb_ivar_get(self, rb_intern("lock_holder"));
 
     if(lock_holder != current_thread) {
         lock = rb_ivar_get(self, rb_intern("lock"));
@@ -306,7 +305,7 @@ static VALUE NIO_Selector_unlock(VALUE self)
 /* Register an IO object with the selector for the given interests */
 static VALUE NIO_Selector_register(VALUE self, VALUE io, VALUE interests)
 {
-    VALUE args[3] = {self, io, interests};
+    VALUE args[3] = { self, io, interests };
     return NIO_Selector_synchronize(self, NIO_Selector_register_synchronized, args);
 }
 
@@ -317,8 +316,8 @@ static VALUE NIO_Selector_register_synchronized(VALUE *args)
     VALUE monitor_args[3];
     struct NIO_Selector *selector;
 
-    self = args[0];
-    io = args[1];
+    self      = args[0];
+    io        = args[1];
     interests = args[2];
 
     Data_Get_Struct(self, struct NIO_Selector, selector);
@@ -327,7 +326,7 @@ static VALUE NIO_Selector_register_synchronized(VALUE *args)
     }
 
     selectables = rb_ivar_get(self, rb_intern("selectables"));
-    monitor = rb_hash_lookup(selectables, io);
+    monitor     = rb_hash_lookup(selectables, io);
 
     if(monitor != Qnil)
         rb_raise(rb_eArgError, "this IO is already registered with selector");
@@ -346,7 +345,7 @@ static VALUE NIO_Selector_register_synchronized(VALUE *args)
 /* Deregister an IO object from the selector */
 static VALUE NIO_Selector_deregister(VALUE self, VALUE io)
 {
-    VALUE args[2] = {self, io};
+    VALUE args[2] = { self, io };
     return NIO_Selector_synchronize(self, NIO_Selector_deregister_synchronized, args);
 }
 
@@ -356,10 +355,10 @@ static VALUE NIO_Selector_deregister_synchronized(VALUE *args)
     VALUE self, io, selectables, monitor;
 
     self = args[0];
-    io = args[1];
+    io   = args[1];
 
     selectables = rb_ivar_get(self, rb_intern("selectables"));
-    monitor = rb_hash_delete(selectables, io);
+    monitor     = rb_hash_delete(selectables, io);
 
     if(monitor != Qnil) {
         rb_funcall(monitor, rb_intern("close"), 1, Qfalse);
@@ -426,7 +425,7 @@ static VALUE NIO_Selector_select_synchronized(VALUE *args)
     if(rb_block_given_p()) {
         return INT2NUM(ready);
     } else {
-        ready_array = selector->ready_array;
+        ready_array           = selector->ready_array;
         selector->ready_array = Qnil;
         return ready_array;
     }
@@ -438,7 +437,7 @@ static int NIO_Selector_run(struct NIO_Selector *selector, VALUE timeout)
     int result;
     double timeout_val;
 
-    selector->selecting = 1;
+    selector->selecting    = 1;
     selector->wakeup_fired = 0;
 
     if(timeout == Qnil) {
@@ -459,7 +458,7 @@ static int NIO_Selector_run(struct NIO_Selector *selector, VALUE timeout)
     /* libev is patched to release the GIL when it makes its system call */
     ev_run(selector->ev_loop, ev_run_flags);
 
-    result = selector->ready_count;
+    result              = selector->ready_count;
     selector->selecting = selector->ready_count = 0;
 
     if(result > 0 || selector->wakeup_fired) {
@@ -489,7 +488,7 @@ static VALUE NIO_Selector_wakeup(VALUE self)
 /* Close the selector and free system resources */
 static VALUE NIO_Selector_close(VALUE self)
 {
-    VALUE args[1] = {self};
+    VALUE args[1] = { self };
     return NIO_Selector_synchronize(self, NIO_Selector_close_synchronized, args);
 }
 
@@ -507,7 +506,7 @@ static VALUE NIO_Selector_close_synchronized(VALUE *args)
 /* Is the selector closed? */
 static VALUE NIO_Selector_closed(VALUE self)
 {
-    VALUE args[1] = {self};
+    VALUE args[1] = { self };
     return NIO_Selector_synchronize(self, NIO_Selector_closed_synchronized, args);
 }
 
@@ -528,7 +527,6 @@ static VALUE NIO_Selector_is_empty(VALUE self)
     return rb_funcall(selectables, rb_intern("empty?"), 0) == Qtrue ? Qtrue : Qfalse;
 }
 
-
 /* Called whenever a timeout fires on the event loop */
 static void NIO_Selector_timeout_callback(struct ev_loop *ev_loop, struct ev_timer *timer, int revents)
 {
@@ -539,18 +537,19 @@ static void NIO_Selector_wakeup_callback(struct ev_loop *ev_loop, struct ev_io *
 {
     char buffer[128];
     struct NIO_Selector *selector = (struct NIO_Selector *)io->data;
-    selector->selecting = 0;
+    selector->selecting           = 0;
 
     /* Drain the wakeup pipe, giving us level-triggered behavior */
-    while(read(selector->wakeup_reader, buffer, 128) > 0);
+    while(read(selector->wakeup_reader, buffer, 128) > 0)
+        ;
 }
 
 /* libev callback fired whenever a monitor gets an event */
 void NIO_Selector_monitor_callback(struct ev_loop *ev_loop, struct ev_io *io, int revents)
 {
     struct NIO_Monitor *monitor_data = (struct NIO_Monitor *)io->data;
-    struct NIO_Selector *selector = monitor_data->selector;
-    VALUE monitor = monitor_data->self;
+    struct NIO_Selector *selector    = monitor_data->selector;
+    VALUE monitor                    = monitor_data->self;
 
     assert(monitor_data->interests != 0);
 


### PR DESCRIPTION
So, after a lot of work in the wrong direction, I think I found only one reference that GC moves and creates a "dangling pointer"....

If you don't want to merge the automatic C code formatting (which would help collaboration,. IMHO), you can just fix the `monitor.c` file so `NIO_Monitor_mark` isn't empty, but rather:

```c
static void NIO_Monitor_mark(struct NIO_Monitor *monitor)
{
    rb_gc_mark(monitor->self); /* prevent GC.compact from moving the memory */
}
```

After fixing this one line, the tests don't crash on my computer.

P.S.

I was impressed reading through the code base. The code is clean and succinct.

I probably would have coded things way more complicated since I would have avoided any Ruby objects in the C layer and would have used local memory allocators for the C layer objects (so they have a separate memory address pool from the main allocator as well as more locality)...

Maybe it's a good thing my long work was tossed in the bean, [I actually finished adding a local memory allocator for the C layer in a different branch](https://github.com/boazsegev/nio4r/tree/support_gc_compact) (enabled with `ENV['NIO_MEMORY_POOL'] = "1"`) 😅