### PR TITLE
fix for #241

### DIFF
--- a/ext/nio4r/monitor.c
+++ b/ext/nio4r/monitor.c
@@ -66,6 +66,7 @@ static VALUE NIO_Monitor_allocate(VALUE klass)
 
 static void NIO_Monitor_mark(struct NIO_Monitor *monitor)
 {
+    return rb_gc_mark(monitor->self);
 }
 
 static void NIO_Monitor_free(struct NIO_Monitor *monitor)


### PR DESCRIPTION
This should fix the dangling pointer issue caused by `GC.compact` (#241) moving the monitor object's memory address to a new location.