### PR TITLE
avoid possible junk data in `monitor` through memory initialization

### DIFF
--- a/ext/nio4r/monitor.c
+++ b/ext/nio4r/monitor.c
@@ -66,7 +66,8 @@ static VALUE NIO_Monitor_allocate(VALUE klass)
 
 static void NIO_Monitor_mark(struct NIO_Monitor *monitor)
 {
-    return rb_gc_mark(monitor->self);
+    if(monitor && monitor->self)
+        rb_gc_mark(monitor->self);
 }
 
 static void NIO_Monitor_free(struct NIO_Monitor *monitor)

--- a/ext/nio4r/monitor.c
+++ b/ext/nio4r/monitor.c
@@ -4,6 +4,7 @@
  */
 
 #include "nio4r.h"
+#include <assert.h>
 
 static VALUE mNIO = Qnil;
 static VALUE cNIO_Monitor = Qnil;
@@ -60,18 +61,15 @@ void Init_NIO_Monitor()
 static VALUE NIO_Monitor_allocate(VALUE klass)
 {
     struct NIO_Monitor *monitor = (struct NIO_Monitor *)xmalloc(sizeof(struct NIO_Monitor));
-    
-    if(!monitor)
-        return Qnil;
-    
+    assert(monitor);
     *monitor = (struct NIO_Monitor){.self = Qnil};
     return Data_Wrap_Struct(klass, NIO_Monitor_mark, NIO_Monitor_free, monitor);
 }
 
 static void NIO_Monitor_mark(struct NIO_Monitor *monitor)
 {
-    if(monitor && monitor->self != Qnil)
-        rb_gc_mark(monitor->self);
+    assert(monitor);
+    rb_gc_mark(monitor->self);
 }
 
 static void NIO_Monitor_free(struct NIO_Monitor *monitor)

--- a/ext/nio4r/monitor.c
+++ b/ext/nio4r/monitor.c
@@ -64,7 +64,7 @@ static VALUE NIO_Monitor_allocate(VALUE klass)
     if(!monitor)
         return Qnil;
     
-    monitor->self = Qnil;
+    *monitor = (struct NIO_Monitor){.self = Qnil};
     return Data_Wrap_Struct(klass, NIO_Monitor_mark, NIO_Monitor_free, monitor);
 }
 

--- a/ext/nio4r/monitor.c
+++ b/ext/nio4r/monitor.c
@@ -60,13 +60,17 @@ void Init_NIO_Monitor()
 static VALUE NIO_Monitor_allocate(VALUE klass)
 {
     struct NIO_Monitor *monitor = (struct NIO_Monitor *)xmalloc(sizeof(struct NIO_Monitor));
-
+    
+    if(!monitor)
+        return Qnil;
+    
+    monitor->self = Qnil;
     return Data_Wrap_Struct(klass, NIO_Monitor_mark, NIO_Monitor_free, monitor);
 }
 
 static void NIO_Monitor_mark(struct NIO_Monitor *monitor)
 {
-    if(monitor && monitor->self)
+    if(monitor && monitor->self != Qnil)
         rb_gc_mark(monitor->self);
 }
 

--- a/ext/nio4r/monitor.c
+++ b/ext/nio4r/monitor.c
@@ -69,6 +69,7 @@ static VALUE NIO_Monitor_allocate(VALUE klass)
 static void NIO_Monitor_mark(struct NIO_Monitor *monitor)
 {
     assert(monitor);
+    assert(monitor->self);
     rb_gc_mark(monitor->self);
 }
 


### PR DESCRIPTION
This short PR explores the possibility of adding a slightly redundant `if` statement...

The if statement is probably redundant since `rb_gc_mark` tests for special non-allocated "objects" such as `nil`, `false`, embedded numbers etc').

However: (1) since a NULL dereferencing issue was reported; and (2) GC tests this condition only after pushing the stack (so it's faster if we test for it); we might as well add this slightly redundant `if` statement and see if it helps.