### PR TITLE
Move `EV_STANDALONE` definition to `extconf.rb`

### DIFF
--- a/ext/nio4r/extconf.rb
+++ b/ext/nio4r/extconf.rb
@@ -22,6 +22,8 @@ $defs << "-DEV_USE_KQUEUE"       if have_header("sys/event.h") && have_header("s
 $defs << "-DEV_USE_PORT"         if have_type("port_event_t", "port.h")
 $defs << "-DHAVE_SYS_RESOURCE_H" if have_header("sys/resource.h")
 
+$defs << "-DEV_STANDALONE" # prevent libev from assuming "config.h" exists
+
 CONFIG["optflags"] << " -fno-strict-aliasing" unless RUBY_PLATFORM =~ /mswin/
 
 dir_config "nio4r_ext"

--- a/ext/nio4r/libev.h
+++ b/ext/nio4r/libev.h
@@ -1,5 +1,3 @@
-#define EV_STANDALONE /* keeps ev from requiring config.h */
-
 #ifdef _WIN32
 #define EV_SELECT_IS_WINSOCKET 1
 #define EV_USE_MONOTONIC 0


### PR DESCRIPTION
By moving the `EV_STANDALONE` definition to `extconf.rb`, it will persist even when `libev.h` isn't included (i.e., within the `libev` codebase).