### PR TITLE
Update Actions workflow - OS changes & additions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,11 +14,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, macos-latest, windows-latest]
-        ruby: [2.4, 2.5, 2.6, 2.7, jruby, truffleruby-head]
+        os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15, windows-2019 ]
+        ruby: [2.7, 2.6, 2.5, 2.4, jruby, truffleruby-head]
+        include:
+          - { os: ubuntu-16.04, ruby: 2.7 }
+          - { os: ubuntu-16.04, ruby: 2.4 }
+          - { os: macos-11.0  , ruby: 2.7 }
+          - { os: macos-11.0  , ruby: 2.4 }
         exclude:
-          - { os: windows-latest, ruby: jruby }
-          - { os: windows-latest, ruby: truffleruby-head }
+          - { os: windows-2019, ruby: jruby }
+          - { os: windows-2019, ruby: truffleruby-head }
 
     steps:
       - name: repo checkout


### PR DESCRIPTION
Ubuntu - shift to 20.04 & 18.04, run two jobs on 16.04

macOS - add two jobs using 11.0

Notes:

1. With three Ubuntu versions and two macOS versions, I don't know what jobs you'd prefer to run.  'include' jobs are always ran at the end of the workflow, 'exclude' jobs don't change the order.  Only using 'exclude' can result in a lot of them being needed with a sparse matrix.

2. JDK varies between OS's, I think 8 and 11.  The version can be locked if desired.

### Types of Changes

<!-- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.
- [x] CI Update

### Testing