### PR TITLE
Allow pure Ruby and Java NIO::Selector to be initialized with nil

### DIFF
--- a/ext/nio4r/org/nio4r/Selector.java
+++ b/ext/nio4r/org/nio4r/Selector.java
@@ -43,7 +43,7 @@ public class Selector extends RubyObject {
 
     @JRubyMethod
     public IRubyObject initialize(ThreadContext context, IRubyObject backend) {
-        if(backend != context.runtime.newSymbol("java")) {
+        if(backend != context.runtime.newSymbol("java") && !backend.isNil()) {
             throw context.runtime.newArgumentError(":java is the only supported backend");
         }
 

--- a/lib/nio/selector.rb
+++ b/lib/nio/selector.rb
@@ -14,7 +14,7 @@ module NIO
 
     # Create a new NIO::Selector
     def initialize(backend = :ruby)
-      raise ArgumentError, "unsupported backend: #{backend}" unless backend == :ruby
+      raise ArgumentError, "unsupported backend: #{backend}" unless [:ruby, nil].include?(backend)
 
       @selectables = {}
       @lock = Mutex.new

--- a/spec/nio/selector_spec.rb
+++ b/spec/nio/selector_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe NIO::Selector do
       example.reporter.message "Supported backends: #{described_class.backends}"
     end
 
+    it "automatically selects a backend if none or nil is specified" do
+      expect(described_class.new.backend).to eq described_class.new(nil).backend
+    end
+
     it "raises ArgumentError if given an invalid backend" do
       expect { described_class.new(:derp) }.to raise_error ArgumentError
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,8 @@ RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 
+  config.filter_run_when_matching :focus
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
```zsh
jcmfernandes@jcmfernandes-desktop:~/own_devel/nio4r^nil-auto-select-backend ♥
% irb                                                                                21-01-04 - 19:45:34
irb(main):001:0> require 'nio'
=> true
irb(main):002:0> NIO::Selector.new(nil)
=> #<NIO::Selector:0x0000555cdc6c88e0>
irb(main):003:0>
jcmfernandes@jcmfernandes-desktop:~/own_devel/nio4r^nil-auto-select-backend ♥
% env NIO4R_PURE=true irb                                                            21-01-04 - 19:45:49
irb(main):001:0> require 'nio'
=> true
irb(main):002:0> NIO::Selector.new(nil)
Traceback (most recent call last):
        6: from /home/jcmfernandes/.asdf/installs/ruby/2.7.2/bin/irb:23:in `<main>'
        5: from /home/jcmfernandes/.asdf/installs/ruby/2.7.2/bin/irb:23:in `load'
        4: from /home/jcmfernandes/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/irb-1.2.6/exe/irb:11:in `<top (required)>'
        3: from (irb):2
        2: from (irb):2:in `new'
        1: from /home/jcmfernandes/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/nio4r-2.5.4/lib/nio/selector.rb:17:in `initialize'
ArgumentError (unsupported backend: )
```

Trying to make this consistent across all backends. Passing `nil` was only working with libev.

I thought about introducing `:auto` as an explicit way to say "select the best", but at the end of the day that's what `nil` is already doing. Feedback is welcome! :smile_cat:

<!--
  What changes are being made? What problem are you solving?
  What feature/bug is being fixed here?
  If this is an aesthetic change, please include screenshots.
-->

## Types of Changes

<!-- Put an `x` in all the boxes that apply: -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.

## Testing

<!-- Put an `x` in all the boxes that apply: -->
- [x] I added new tests for my changes.
- [x] I ran all the tests locally.
