### PR TITLE
Workaround for ARM-based macOS Ruby

### DIFF
--- a/lib/nio.rb
+++ b/lib/nio.rb
@@ -14,7 +14,7 @@ module NIO
   end
 end
 
-if ENV["NIO4R_PURE"] == "true" || (Gem.win_platform? && !defined?(JRUBY_VERSION))
+if ENV["NIO4R_PURE"] == "true" || (Gem.win_platform? && !defined?(JRUBY_VERSION)) || (RUBY_PLATFORM =~ /darwin/ && RUBY_PLATFORM =~ /arm64/)
   require "nio/monitor"
   require "nio/selector"
   require "nio/bytebuffer"


### PR DESCRIPTION
This is a workaround to force enable pure Ruby implementation on ARM-based macOS Ruby (both custom-build & system-bundled)

Ref https://github.com/socketry/nio4r/issues/259

NOTE:

Custom Ruby

```
jasl@bogon:~$ rbenv shell 3.0.0
jasl@bogon:~$ irb
irb(main):001:0> RUBY_PLATFORM
=> "arm64-darwin20"
```

System Ruby

```
jasl@bogon:~$ rbenv shell system
jasl@bogon:~$ irb

WARNING: This version of ruby is included in macOS for compatibility with legacy software.
In future versions of macOS the ruby runtime will not be available by
default, and may require you to install an additional package.

irb(main):001:0> RUBY_PLATFORM
=> "universal.arm64e-darwin20"
```

## Types of Changes

- [x] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.

## Testing

- [ ] I added new tests for my changes.
- [ ] I ran all the tests locally.
