### PR TITLE
CI: Remove the macos-11.0 target, for now

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,8 +19,6 @@ jobs:
         include:
           - { os: ubuntu-16.04, ruby: 3.0 }
           - { os: ubuntu-16.04, ruby: 2.4 }
-          - { os: macos-11.0  , ruby: 3.0 }
-          - { os: macos-11.0  , ruby: 2.4 }
         exclude:
           - { os: windows-2019, ruby: head  }
           - { os: windows-2019, ruby: jruby }


### PR DESCRIPTION

## Description

This fixes #264 by holding off building on a not-yet-supported platform combination.

We can add it back when it reappears as a supported GitHub Actions platform.

### Types of Changes

- Maintenance.

### Testing

- See CI run