### PR TITLE
Don't try to link universal extension.

### DIFF
--- a/ext/nio4r/extconf.rb
+++ b/ext/nio4r/extconf.rb
@@ -27,5 +27,9 @@ $defs << "-DEV_STANDALONE" # prevent libev from assuming "config.h" exists
 
 CONFIG["optflags"] << " -fno-strict-aliasing" unless RUBY_PLATFORM =~ /mswin/
 
+if RUBY_PLATFORM =~ /darwin/
+  $DLDFLAGS.gsub!(/\-arch\s+[^\s]+/, "")
+end
+
 dir_config "nio4r_ext"
 create_makefile "nio4r_ext"

--- a/lib/nio.rb
+++ b/lib/nio.rb
@@ -25,9 +25,9 @@ module NIO
     end
 
     # M1 native extension is crashing on M1 (arm64):
-    if RUBY_PLATFORM =~ /darwin/ && RUBY_PLATFORM =~ /arm64/
-      return true
-    end
+    # if RUBY_PLATFORM =~ /darwin/ && RUBY_PLATFORM =~ /arm64/
+    #   return true
+    # end
 
     return false
   end


### PR DESCRIPTION
## Description

It seems like `mkmf` will try to use the `RbConfig` `DLDFLAGS` which contains `-arch` flags which confuse the linker, causing the resulting library to be completely empty. We delete those `-arch` flags before generating the makefile, so that the resulting library is build only for the system's native architecture.

See https://github.com/socketry/nio4r/issues/259 for more details.

### Types of Changes

- Bug fix.
- Maintenance.

### Testing

- [x] I tested my changes locally.
