### PR TITLE
Prefer kqueue when on OSX  >= v10.12.2 

### DIFF
--- a/ext/libev/ev.c
+++ b/ext/libev/ev.c
@@ -3147,8 +3147,10 @@ ev_recommended_backends (void) EV_NOEXCEPT
   /* only select works correctly on that "unix-certified" platform */
   flags &= ~EVBACKEND_KQUEUE; /* horribly broken, even for sockets */
   flags &= ~EVBACKEND_POLL;   /* poll is based on kqueue from 10.5 onwards */
-#elif !defined(__NetBSD__)
-  /* kqueue is borked on everything but netbsd apparently */
+#endif
+
+#if !defined(__NetBSD__) && !defined(__APPLE__)
+  /* kqueue is borked on everything but netbsd and osx >= 10.12.2 apparently */
   /* it usually doesn't work correctly on anything but sockets and pipes */
   flags &= ~EVBACKEND_KQUEUE;
 #endif

--- a/ext/libev/ev.c
+++ b/ext/libev/ev.c
@@ -354,19 +354,11 @@
 #endif
 
 #ifndef EV_USE_LINUXAIO
-# if __linux /* libev currently assumes linux/aio_abi.h is always available on linux */
-#  define EV_USE_LINUXAIO 0 /* was: 1, always off by default */
-# else
 #  define EV_USE_LINUXAIO 0
-# endif
 #endif
 
 #ifndef EV_USE_IOURING
-# if __linux /* later checks might disable again */
-#  define EV_USE_IOURING 1
-# else
 #  define EV_USE_IOURING 0
-# endif
 #endif
 
 #ifndef EV_USE_INOTIFY
@@ -473,14 +465,6 @@
 #if !EV_STAT_ENABLE
 # undef EV_USE_INOTIFY
 # define EV_USE_INOTIFY 0
-#endif
-
-#if __linux && EV_USE_IOURING
-# include <linux/version.h>
-# if LINUX_VERSION_CODE < KERNEL_VERSION(4,14,0)
-#  undef EV_USE_IOURING
-#  define EV_USE_IOURING 0
-# endif
 #endif
 
 #if !EV_USE_NANOSLEEP


### PR DESCRIPTION
## Description

This a regression I introduced in 2.5.5 (sorry!). I got my hands on a Mac to confirm it (and test this fix).

I'm also taking the chance to address https://github.com/socketry/nio4r/issues/266#issuecomment-782430078 as given that we check for `linux/io_uring.h` in `extconf.rb`, and that header was only introduced in Linux 5.1, my change is safe. In fact, while libev was looking for Linux >= 4.14 to compile safely, the backend is only activated on systems with kernel >= 5.6.1.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
