### PR TITLE
Fix incorrect return types. Fixes #275.

### DIFF
--- a/ext/libev/ev_iouring.c
+++ b/ext/libev/ev_iouring.c
@@ -287,7 +287,7 @@ iouring_sqe_get (EV_P)
 }
 
 inline_size
-struct io_uring_sqe *
+void
 iouring_sqe_submit (EV_P_ struct io_uring_sqe *sqe)
 {
   unsigned idx = sqe - EV_SQES;
@@ -313,7 +313,7 @@ iouring_tfd_cb (EV_P_ struct ev_io *w, int revents)
 
 /* called for full and partial cleanup */
 ecb_cold
-static int
+static void
 iouring_internal_destroy (EV_P)
 {
   close (iouring_tfd);


### PR DESCRIPTION
## Description

According to #275, `libev` implementation of uring has some "syntax errors", as in it declares some return type but doesn't return anything.

I checked and this is superficial, as in there were no cases where the (undefined) return value was ever used.

There is no update to `libev` yet with these fixes, but a quick check upstream shows that they are fixed already.

So I manually fixed the code by hand as a short term solution.

cc @tyan-boot

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
