### PR TITLE
allow missing `devkit`

### DIFF
--- a/ext/nio4r/extconf.rb
+++ b/ext/nio4r/extconf.rb
@@ -4,7 +4,10 @@ require "rubygems"
 
 # Write a dummy Makefile on Windows because we use the pure Ruby implementation there
 if Gem.win_platform?
-  require "devkit" if RUBY_PLATFORM.include?("mingw")
+  begin
+    require "devkit" if RUBY_PLATFORM.include?("mingw")
+  rescue LoadError => e
+  end
   File.write("Makefile", "all install::\n")
   File.write("nio4r_ext.so", "")
   exit


### PR DESCRIPTION
## Description

As per the comments in the build file, windows does not actually use
any native extension code.

Not sure why the require was added for `devkit`.  In the interest of
compatibility simply guard the require with a rescue for the `LoadError`.

If the Ruby environment was custom built the `devkit` class will not
always be available. In some cases such as more recent builds for
Ruby 3.0.x the devkit can utilize an MSYS2 environment without needing
the `devkit` class.

### Types of Changes

- Bug fix.

### Testing

- [ ] I tested my changes locally.
