### PR TITLE
Resolve issue loading both nio and nio4r gems

### DIFF
--- a/lib/nio4r.rb
+++ b/lib/nio4r.rb
@@ -1,0 +1,1 @@
+require_relative "nio"


### PR DESCRIPTION
I've got an older application that uses the `nio` gem https://rubygems.org/gems/nio.

While updating to use puma I hit `uninitialized constant NIO (NameError)` as an error as the `Nio` constant is loaded first.

This change allows loading nio4r explicitly.

```
gem 'nio', '~> 0.2.5'
gem 'nio4r', require: 'nio4r'
gem 'puma'
```