### PR TITLE
Fix changelog_uri in gemspec metadata

### DIFF
--- a/nio4r.gemspec
+++ b/nio4r.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata = {
     "bug_tracker_uri"   => "https://github.com/socketry/nio4r/issues",
-    "changelog_uri"     => "https://github.com/socketry/nio4r/blob/master/CHANGES.md",
+    "changelog_uri"     => "https://github.com/socketry/nio4r/blob/main/changes.md",
     "documentation_uri" => "https://www.rubydoc.info/gems/nio4r/#{spec.version}",
     "source_code_uri"   => "https://github.com/socketry/nio4r/tree/v#{spec.version}",
     "wiki_uri"          => "https://github.com/socketry/nio4r/wiki"


### PR DESCRIPTION
Since changelog has been renamed to `changes.md` (lowercase), and the default branch is `main`, its uri has to be changed.

## Types of Changes

- Bug fix.

## Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
