### PR TITLE
Fix license

### DIFF
--- a/license.md
+++ b/license.md
@@ -69,7 +69,8 @@ SOFTWARE.
 
 ## libev
 
-Released under the BSD license. See [ext/libev/LICENSE] for details.
+Released under the BSD-2-Clause OR GPL-2.0-or-later license.
+See [ext/libev/LICENSE] for details.
 
 Copyright, 2007-2019, by Marc Alexander Lehmann.
 

--- a/nio4r.gemspec
+++ b/nio4r.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Tony Arcieri"]
   spec.email         = ["bascule@gmail.com"]
   spec.homepage      = "https://github.com/socketry/nio4r"
-  spec.license       = "MIT"
+  spec.license       = "MIT AND (BSD-2-Clause OR GPL-2.0-or-later)"
   spec.summary       = "New IO for Ruby"
   spec.description   = <<-DESCRIPTION.strip.gsub(/\s+/, " ")
      Cross-platform asynchronous I/O primitives for scalable network clients


### PR DESCRIPTION
Add libev licenses (BSD-2-Clause OR GPL-2.0-or-later) into gem metadata.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
