### PR TITLE
Convert NIO objects to TypedData API

### DIFF
--- a/ext/nio4r/bytebuffer.c
+++ b/ext/nio4r/bytebuffer.c
@@ -8,8 +8,8 @@ static VALUE cNIO_ByteBuffer_MarkUnsetError = Qnil;
 
 /* Allocator/deallocator */
 static VALUE NIO_ByteBuffer_allocate(VALUE klass);
-static void NIO_ByteBuffer_gc_mark(struct NIO_ByteBuffer *byteBuffer);
-static void NIO_ByteBuffer_free(struct NIO_ByteBuffer *byteBuffer);
+static void NIO_ByteBuffer_free(void *data);
+static size_t NIO_ByteBuffer_memsize(const void *data);
 
 /* Methods */
 static VALUE NIO_ByteBuffer_initialize(VALUE self, VALUE capacity);
@@ -92,28 +92,46 @@ void Init_NIO_ByteBuffer()
     rb_define_method(cNIO_ByteBuffer, "inspect", NIO_ByteBuffer_inspect, 0);
 }
 
+static const rb_data_type_t NIO_ByteBuffer_type = {
+    "NIO::ByteBuffer",
+    {
+        NULL, // Nothing to mark
+        NIO_ByteBuffer_free,
+        NIO_ByteBuffer_memsize,
+    },
+    0,
+    0,
+    RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
+};
+
 static VALUE NIO_ByteBuffer_allocate(VALUE klass)
 {
     struct NIO_ByteBuffer *bytebuffer = (struct NIO_ByteBuffer *)xmalloc(sizeof(struct NIO_ByteBuffer));
     bytebuffer->buffer = NULL;
-    return Data_Wrap_Struct(klass, NIO_ByteBuffer_gc_mark, NIO_ByteBuffer_free, bytebuffer);
+    return TypedData_Wrap_Struct(klass, &NIO_ByteBuffer_type, bytebuffer);
 }
 
-static void NIO_ByteBuffer_gc_mark(struct NIO_ByteBuffer *buffer)
+static void NIO_ByteBuffer_free(void *data)
 {
-}
-
-static void NIO_ByteBuffer_free(struct NIO_ByteBuffer *buffer)
-{
+    struct NIO_ByteBuffer *buffer = (struct NIO_ByteBuffer *)data;
     if (buffer->buffer)
         xfree(buffer->buffer);
     xfree(buffer);
 }
 
+static size_t NIO_ByteBuffer_memsize(const void *data)
+{
+    const struct NIO_ByteBuffer *buffer = (const struct NIO_ByteBuffer *)data;
+    size_t memsize = sizeof(struct NIO_ByteBuffer);
+    if (buffer->buffer)
+        memsize += buffer->capacity;
+    return memsize;
+}
+
 static VALUE NIO_ByteBuffer_initialize(VALUE self, VALUE capacity)
 {
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     buffer->capacity = NUM2INT(capacity);
     buffer->buffer = xmalloc(buffer->capacity);
@@ -126,7 +144,7 @@ static VALUE NIO_ByteBuffer_initialize(VALUE self, VALUE capacity)
 static VALUE NIO_ByteBuffer_clear(VALUE self)
 {
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     memset(buffer->buffer, 0, buffer->capacity);
 
@@ -140,7 +158,7 @@ static VALUE NIO_ByteBuffer_clear(VALUE self)
 static VALUE NIO_ByteBuffer_get_position(VALUE self)
 {
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     return INT2NUM(buffer->position);
 }
@@ -149,7 +167,7 @@ static VALUE NIO_ByteBuffer_set_position(VALUE self, VALUE new_position)
 {
     int pos;
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     pos = NUM2INT(new_position);
 
@@ -173,7 +191,7 @@ static VALUE NIO_ByteBuffer_set_position(VALUE self, VALUE new_position)
 static VALUE NIO_ByteBuffer_get_limit(VALUE self)
 {
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     return INT2NUM(buffer->limit);
 }
@@ -182,7 +200,7 @@ static VALUE NIO_ByteBuffer_set_limit(VALUE self, VALUE new_limit)
 {
     int lim;
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     lim = NUM2INT(new_limit);
 
@@ -210,7 +228,7 @@ static VALUE NIO_ByteBuffer_set_limit(VALUE self, VALUE new_limit)
 static VALUE NIO_ByteBuffer_capacity(VALUE self)
 {
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     return INT2NUM(buffer->capacity);
 }
@@ -218,7 +236,7 @@ static VALUE NIO_ByteBuffer_capacity(VALUE self)
 static VALUE NIO_ByteBuffer_remaining(VALUE self)
 {
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     return INT2NUM(buffer->limit - buffer->position);
 }
@@ -226,7 +244,7 @@ static VALUE NIO_ByteBuffer_remaining(VALUE self)
 static VALUE NIO_ByteBuffer_full(VALUE self)
 {
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     return buffer->position == buffer->limit ? Qtrue : Qfalse;
 }
@@ -236,7 +254,7 @@ static VALUE NIO_ByteBuffer_get(int argc, VALUE *argv, VALUE self)
     int len;
     VALUE length, result;
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     rb_scan_args(argc, argv, "01", &length);
 
@@ -264,7 +282,7 @@ static VALUE NIO_ByteBuffer_fetch(VALUE self, VALUE index)
 {
     int i;
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     i = NUM2INT(index);
 
@@ -283,7 +301,7 @@ static VALUE NIO_ByteBuffer_put(VALUE self, VALUE string)
 {
     long length;
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     StringValue(string);
     length = RSTRING_LEN(string);
@@ -303,7 +321,7 @@ static VALUE NIO_ByteBuffer_read_from(VALUE self, VALUE io)
     struct NIO_ByteBuffer *buffer;
     ssize_t nbytes, bytes_read;
 
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     io = rb_convert_type(io, T_FILE, "IO", "to_io");
     io_set_nonblock(io);
@@ -333,7 +351,7 @@ static VALUE NIO_ByteBuffer_write_to(VALUE self, VALUE io)
     struct NIO_ByteBuffer *buffer;
     ssize_t nbytes, bytes_written;
 
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
     io = rb_convert_type(io, T_FILE, "IO", "to_io");
     io_set_nonblock(io);
 
@@ -360,7 +378,7 @@ static VALUE NIO_ByteBuffer_write_to(VALUE self, VALUE io)
 static VALUE NIO_ByteBuffer_flip(VALUE self)
 {
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     buffer->limit = buffer->position;
     buffer->position = 0;
@@ -372,7 +390,7 @@ static VALUE NIO_ByteBuffer_flip(VALUE self)
 static VALUE NIO_ByteBuffer_rewind(VALUE self)
 {
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     buffer->position = 0;
     buffer->mark = MARK_UNSET;
@@ -383,7 +401,7 @@ static VALUE NIO_ByteBuffer_rewind(VALUE self)
 static VALUE NIO_ByteBuffer_mark(VALUE self)
 {
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     buffer->mark = buffer->position;
     return self;
@@ -392,7 +410,7 @@ static VALUE NIO_ByteBuffer_mark(VALUE self)
 static VALUE NIO_ByteBuffer_reset(VALUE self)
 {
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     if (buffer->mark < 0) {
         rb_raise(cNIO_ByteBuffer_MarkUnsetError, "mark has not been set");
@@ -406,7 +424,7 @@ static VALUE NIO_ByteBuffer_reset(VALUE self)
 static VALUE NIO_ByteBuffer_compact(VALUE self)
 {
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     memmove(buffer->buffer, buffer->buffer + buffer->position, buffer->limit - buffer->position);
     buffer->position = buffer->limit - buffer->position;
@@ -419,7 +437,7 @@ static VALUE NIO_ByteBuffer_each(VALUE self)
 {
     int i;
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     if (rb_block_given_p()) {
         for (i = 0; i < buffer->limit; i++) {
@@ -435,7 +453,7 @@ static VALUE NIO_ByteBuffer_each(VALUE self)
 static VALUE NIO_ByteBuffer_inspect(VALUE self)
 {
     struct NIO_ByteBuffer *buffer;
-    Data_Get_Struct(self, struct NIO_ByteBuffer, buffer);
+    TypedData_Get_Struct(self, struct NIO_ByteBuffer, &NIO_ByteBuffer_type, buffer);
 
     return rb_sprintf(
         "#<%s:%p @position=%d @limit=%d @capacity=%d>",

--- a/ext/nio4r/monitor.c
+++ b/ext/nio4r/monitor.c
@@ -129,7 +129,7 @@ static VALUE NIO_Monitor_initialize(VALUE self, VALUE io, VALUE interests, VALUE
     rb_ivar_set(self, rb_intern("interests"), interests);
     rb_ivar_set(self, rb_intern("selector"), selector_obj);
 
-    Data_Get_Struct(selector_obj, struct NIO_Selector, selector);
+    selector = NIO_Selector_unwrap(selector_obj);
 
     RB_OBJ_WRITE(self, &monitor->self, self);
     monitor->ev_io.data = (void *)monitor;

--- a/ext/nio4r/nio4r.h
+++ b/ext/nio4r/nio4r.h
@@ -40,6 +40,8 @@ struct NIO_ByteBuffer {
     int position, limit, capacity, mark;
 };
 
+struct NIO_Selector *NIO_Selector_unwrap(VALUE selector);
+
 /* Thunk between libev callbacks in NIO::Monitors and NIO::Selectors */
 void NIO_Selector_monitor_callback(struct ev_loop *ev_loop, struct ev_io *io, int revents);
 


### PR DESCRIPTION
The replacement API was introduced in Ruby 1.9.2 (2010),
and the old untyped data API was marked a deprecated in the documentation
as of Ruby 2.3.0 (2015)

Ref: https://bugs.ruby-lang.org/issues/19998

Since it was quite trivial I also implemented write barriers and memsize functions.