### PR TITLE
Convert license to array of identifiers

### DIFF
--- a/nio4r.gemspec
+++ b/nio4r.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Tony Arcieri"]
   spec.email         = ["bascule@gmail.com"]
   spec.homepage      = "https://github.com/socketry/nio4r"
-  spec.license       = "MIT AND (BSD-2-Clause OR GPL-2.0-or-later)"
+  spec.licenses      = ["MIT", "BSD-2-Clause", "GPL-2.0-or-later"]
   spec.summary       = "New IO for Ruby"
   spec.description   = <<-DESCRIPTION.strip.gsub(/\s+/, " ")
      Cross-platform asynchronous I/O primitives for scalable network clients

--- a/nio4r.gemspec
+++ b/nio4r.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Tony Arcieri"]
   spec.email         = ["bascule@gmail.com"]
   spec.homepage      = "https://github.com/socketry/nio4r"
-  spec.licenses      = ["MIT", "BSD-2-Clause", "GPL-2.0-or-later"]
+  spec.licenses      = ["MIT", "BSD-2-Clause"]
   spec.summary       = "New IO for Ruby"
   spec.description   = <<-DESCRIPTION.strip.gsub(/\s+/, " ")
      Cross-platform asynchronous I/O primitives for scalable network clients


### PR DESCRIPTION
RubyGems currently complain during gem build:

~~~
WARNING:  license value 'MIT AND (BSD-2-Clause OR GPL-2.0-or-later)' is invalid.
Use a license identifier from http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
Did you mean 'AGPL-1.0-or-later', 'AGPL-3.0-or-later', 'BSD-2-Clause-Patent', 'GPL-2.0-or-later', 'LGPL-2.0-or-later'?
~~~

Nothing else then plain list of license identifers is supported ATM.

Relates #309

<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
