### PR TITLE
JRuby supports Java 8 and higher.  Need to emit Java 8 classfile format

### DIFF
--- a/rakelib/extension.rake
+++ b/rakelib/extension.rake
@@ -4,7 +4,7 @@ if defined? JRUBY_VERSION
   require "rake/javaextensiontask"
   Rake::JavaExtensionTask.new("nio4r_ext") do |ext|
     ext.ext_dir = "ext/nio4r"
-    ext.release = '9'
+    ext.release = '8'
   end
 else
   require "rake/extensiontask"


### PR DESCRIPTION
JRuby supports Java 8 and higher.  Need to emit Java 8 classfile format. Addresses #316

## Types of Changes

- Bug fix.


## Contribution

This reverts a change from this last April.  Unless there is some GHA action or gem release issue nothing should change other than the classfile format that Java uses to write out its bytecode.

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
