### PR TITLE
Mark as ractor-safe

### DIFF
--- a/ext/nio4r/nio4r_ext.c
+++ b/ext/nio4r/nio4r_ext.c
@@ -12,6 +12,10 @@ void Init_NIO_ByteBuffer();
 
 void Init_nio4r_ext()
 {
+    #ifdef HAVE_RB_EXT_RACTOR_SAFE
+    rb_ext_ractor_safe(true);
+    #endif
+
     ev_set_allocator(xrealloc);
 
     Init_NIO_Selector();


### PR DESCRIPTION
Closes https://github.com/socketry/nio4r/issues/318

## Types of Changes

- Performance improvement when using nio4r in Ractor, and also for when TruffleRuby can run rb_ext_ractor_safe C-extensions in parallel.

## Contribution

- [x] I tested my changes locally. 
On MacOS 15.0, 
uname -a: `Darwin mohameds-mbp.lan 24.0.0 Darwin Kernel Version 24.0.0: Mon Aug 12 20:51:54 PDT 2024; root:xnu-11215.1.10~2/RELEASE_ARM64_T6000 arm64`
Ruby versions: 3.1.6 and 3.3.5
Results: `112 examples, 0 failures, 2 pending`
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).

**STILL REQUIRED:**
- [ ] someone with more comfort with C-extensions to review if any global state is used and if the extension really is already fully Ractor-safe
- [ ] Possibly add tests for changes? Might be hard to test for concurrency issues