### PR TITLE
Update CI matrix.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,7 @@ jobs:
         exclude:
           - {os: windows-latest, ruby: head}
           - {os: windows-latest, ruby: jruby}
+          - {os: macos-latest, ruby: jruby}
           - {os: windows-latest, ruby: truffleruby}
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,6 @@ jobs:
           - macos-latest
           - windows-latest
         ruby:
-          - "2.5"
           - "2.6"
           - "2.7"
           - "3.0"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         os: 
-          - ubuntu-22.04
-          - macos-11
-          - windows-2022
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
         ruby:
           - "2.5"
           - "2.6"
@@ -29,8 +29,6 @@ jobs:
           - "jruby"
           - "truffleruby"
         include:
-          - {os: ubuntu-20.04, ruby: "3.2"}
-          - {os: windows-2019, ruby: "3.2"}
           - {os: windows-2022, ruby: ucrt}
         exclude:
           - {os: windows-2022, ruby: head}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,15 +24,16 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
+          - "3.3"
           - "head"
           - "jruby"
           - "truffleruby"
         include:
           - {os: windows-2022, ruby: ucrt}
         exclude:
-          - {os: windows-2022, ruby: head}
-          - {os: windows-2022, ruby: jruby}
-          - {os: windows-2022, ruby: truffleruby}
+          - {os: windows-latest, ruby: head}
+          - {os: windows-latest, ruby: jruby}
+          - {os: windows-latest, ruby: truffleruby}
 
     steps:
       - uses: actions/checkout@v3

--- a/nio4r.gemspec
+++ b/nio4r.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob(['{ext,lib}/**/*', '*.md'], File::FNM_DOTMATCH, base: __dir__)
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ">= 2.4"
+  spec.required_ruby_version = ">= 2.6"
 
   if defined? JRUBY_VERSION
     spec.files << "lib/nio4r_ext.jar"


### PR DESCRIPTION
The `macos-11` os no longer works.

## Types of Changes

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
