### PR TITLE
Test on macos-14

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: 
           - ubuntu-22.04
-          - macos-11
+          - macos-14
           - windows-2022
         ruby:
           - "2.5"


### PR DESCRIPTION
Updated the version of Mac we run our tests on, since macos-11 is no longer supported

## Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
